### PR TITLE
[#82] badge, navigation bar 오류 수정

### DIFF
--- a/src/components/chips/badge/badge.tsx
+++ b/src/components/chips/badge/badge.tsx
@@ -1,6 +1,7 @@
 import styles from "./badge.module.css";
 import { BADGE_COLORS } from "@/components/chips/badge/badge-colors";
 import typographyStyles from "@/components/typography/typography.module.css";
+import { useMemo } from "react";
 
 interface BadgeProps {
   colorIndex?: number;
@@ -9,7 +10,15 @@ interface BadgeProps {
 
 export default function Badge({ colorIndex = 0, title = "" }: BadgeProps) {
   const badgeClasses = `${styles.badge} ${typographyStyles["sm-semibold"]}`;
-  const calculateColorIndex = colorIndex % BADGE_COLORS.length;
+  const calculateColorIndex = useMemo(() => {
+    if (colorIndex !== undefined) {
+      return colorIndex % BADGE_COLORS.length;
+    }
+    const hash = title.split("").reduce((acc, char, index) => {
+      return acc + char.charCodeAt(0) * (index + 1);
+    }, 0);
+    return hash % BADGE_COLORS.length;
+  }, [colorIndex, title]);
 
   return (
     <span className={badgeClasses} style={BADGE_COLORS[calculateColorIndex]}>

--- a/src/components/chips/badge/badge.tsx
+++ b/src/components/chips/badge/badge.tsx
@@ -8,12 +8,17 @@ interface BadgeProps {
   title: string;
 }
 
-export default function Badge({ colorIndex = 0, title = "" }: BadgeProps) {
+export default function Badge({ colorIndex = 0, title }: BadgeProps) {
   const badgeClasses = `${styles.badge} ${typographyStyles["sm-semibold"]}`;
+
+  const trimmedTitle = title.trim();
+  if (!trimmedTitle) return null;
+
   const calculateColorIndex = useMemo(() => {
     if (colorIndex !== undefined) {
       return colorIndex % BADGE_COLORS.length;
     }
+
     const hash = title.split("").reduce((acc, char, index) => {
       return acc + char.charCodeAt(0) * (index + 1);
     }, 0);

--- a/src/components/chips/badge/badge.tsx
+++ b/src/components/chips/badge/badge.tsx
@@ -8,7 +8,7 @@ interface BadgeProps {
   title: string;
 }
 
-export default function Badge({ colorIndex = 0, title }: BadgeProps) {
+export default function Badge({ colorIndex, title }: BadgeProps) {
   const badgeClasses = `${styles.badge} ${typographyStyles["sm-semibold"]}`;
 
   const trimmedTitle = title.trim();

--- a/src/components/chips/badge/badge.tsx
+++ b/src/components/chips/badge/badge.tsx
@@ -4,26 +4,21 @@ import typographyStyles from "@/components/typography/typography.module.css";
 import { useMemo } from "react";
 
 interface BadgeProps {
-  colorIndex?: number;
   title: string;
 }
 
-export default function Badge({ colorIndex, title }: BadgeProps) {
+export default function Badge({ title }: BadgeProps) {
   const badgeClasses = `${styles.badge} ${typographyStyles["sm-semibold"]}`;
 
   const trimmedTitle = title.trim();
   if (!trimmedTitle) return null;
 
   const calculateColorIndex = useMemo(() => {
-    if (colorIndex !== undefined) {
-      return colorIndex % BADGE_COLORS.length;
-    }
-
     const hash = title.split("").reduce((acc, char, index) => {
       return acc + char.charCodeAt(0) * (index + 1);
     }, 0);
     return hash % BADGE_COLORS.length;
-  }, [colorIndex, title]);
+  }, [title]);
 
   return (
     <span className={badgeClasses} style={BADGE_COLORS[calculateColorIndex]}>

--- a/src/components/navigationBar/navigation-bar.tsx
+++ b/src/components/navigationBar/navigation-bar.tsx
@@ -40,6 +40,8 @@ export default function NavigationBar({
   if (members.length > 6) {
     showMembers = members.slice(0, 5);
     hideMembers = members.slice(5);
+  } else {
+    showMembers = members;
   }
 
   return (

--- a/src/pages/test-components/index.tsx
+++ b/src/pages/test-components/index.tsx
@@ -433,8 +433,8 @@ function BadgeSample() {
           gap: `10px`,
         }}
       >
-        {Object.values(ProfileRandomColor).map((profile, colorIndex) => (
-          <Badge key={colorIndex} title={"태그내용"} colorIndex={colorIndex} />
+        {Object.values(ProfileRandomColor).map((profile, index) => (
+          <Badge key={index} title={"태그내용"} />
         ))}
       </div>
     </>


### PR DESCRIPTION
## 📝 작업 내용

> 
mergy중 코드가 좀 지워진거 같아서 수정
badge 부분에 컬러 랜덤으로 받도록 다시 추가했습니다.
근데 이게 랜덤으로 하다보니까 같은색상이 여러번 나올수도있겠다 싶어서
글자에따라서 색상을 다르게값을 줄수있도록 했는데
애초에 프로필컬러가 많지가 않아서 이래도 중복 될수도..

그리고 navigationbar에서
멤버수가 6명 이상인경우에만 프로필이 나타나게 되어있어서 수정했습니다.

---

1. badge에 colorindex가 undefined이거나 하는경우 무조건 index를 0으로 초기화하기때문에
index == 0 에 해당하는 색상만 나옴. -> colorindex가 들어오면 index값에따라서 색상을 뿌리고, index 값이 들어오지 않으면 title 글자 값을 숫자로 연산해서 하는건데.. .음.. 굳이? 싶기도 하고. 
그냥 이런방법도 있다고 나오길래 써봤어요.

2. navigationbar에서 memberlist가 lengh 6이하면 멤버가 표시되지 않는 오류.
-> 그냥 코드 오류라서 조건문으로 처리.