### PR TITLE
[#55] 나의 대시보드 데이터 없는 화면

### DIFF
--- a/src/pages/my-dashboard/index.tsx
+++ b/src/pages/my-dashboard/index.tsx
@@ -1,0 +1,29 @@
+import { getDashboards } from "@/components/dashboard-side-bar/api/dashboard";
+import DashboardSideBar from "@/components/dashboard-side-bar/dashboard-side-bar";
+import { useSsrResponsive } from "@/hooks/use-ssr-responsive";
+import { useEffect, useState } from "react";
+import MyDashboardMain from "./my-dashboard-main";
+import styles from "./my-dashboard.module.css";
+
+export default function MyDashboard() {
+  const [dashboards, setDashboards] = useState<any[]>([]);
+  useEffect(() => {
+    const loadData = async () => {
+      try {
+        const { dashboards } = await getDashboards();
+        setDashboards(dashboards);
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    loadData();
+  }, []);
+  const { isMobile } = useSsrResponsive();
+
+  return (
+    <div className={styles.myDashboardWrap}>
+      {!isMobile && <DashboardSideBar dashboards={dashboards} />}
+      <MyDashboardMain />
+    </div>
+  );
+}

--- a/src/pages/my-dashboard/my-dashboard-main.tsx
+++ b/src/pages/my-dashboard/my-dashboard-main.tsx
@@ -1,0 +1,70 @@
+import NotInvitedImg from "@/assets/images/ic-invite.svg";
+import EmptyDashboardImg from "@/assets/images/ic-my-dashboard.svg";
+import PlusIcon from "@/assets/images/ic-plus-circle.svg";
+import NavigationBar from "@/components/navigationBar/navigation-bar";
+import Typography from "@/components/typography";
+import { useResponsiveValue } from "@/hooks/use-responsive-value";
+import Image from "next/image";
+import styles from "./my-dashboard.module.css";
+
+export default function MyDashboardMain() {
+  const homeText = useResponsiveValue({
+    desktop: Typography.xl3Bold,
+    tablet: Typography.xl2Bold,
+    mobile: Typography.xlBold,
+  });
+
+  const sectionTitle = useResponsiveValue({
+    desktop: Typography.xlBold,
+    tablet: Typography.lg2Bold,
+    mobile: Typography.lgBold
+  })
+
+  const emptyText = useResponsiveValue({
+    desktop: Typography.lg2Bold,
+    tablet: Typography.lgBold,
+    mobile: Typography.mdBold,
+  });
+
+  return (
+    <div className={styles.myDashboardMainWrap}>
+      <NavigationBar />
+      <div className={styles.myDashboardMain}>
+        <h1 className={homeText}>홈</h1>
+        <div className={styles.dashboardSection}>
+          <h2 className={sectionTitle}>내 대시보드</h2>
+          <div className={styles.emptyDashboard}>
+            <Image
+              src={EmptyDashboardImg}
+              width={100}
+              height={100}
+              alt="대시보드가 없다"
+            />
+            <p className={emptyText}>대시보드가 없습니다.</p>
+            <button>
+              <span className={Typography.lgBold}>생성하기</span>
+              <Image
+                src={PlusIcon}
+                width={16}
+                height={16}
+                alt="대시보드 생성"
+              />
+            </button>
+          </div>
+        </div>
+        <div className={styles.dashboardSection}>
+          <h2 className={sectionTitle}>초대 받은 대시보드</h2>
+          <div className={styles.emptyDashboard}>
+            <Image
+              src={NotInvitedImg}
+              width={100}
+              height={100}
+              alt="초대 받은 대시보드가 없다"
+            />
+            <p className={emptyText}>아직 초대받은 대시보드가 없습니다.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/my-dashboard/my-dashboard.module.css
+++ b/src/pages/my-dashboard/my-dashboard.module.css
@@ -1,0 +1,96 @@
+.myDashboardWrap {
+  display: flex;
+}
+.myDashboardMainWrap {
+  width: 100%;
+  background: var(--color-background);
+}
+.myDashboardMain {
+  padding: 0 50px;
+}
+.myDashboardMain h1 {
+  color: var(--color-gray100);
+  padding: 24px 0 14px;
+}
+.myDashboardMain .dashboardSection {
+  padding-bottom: 50px;
+}
+.myDashboardMain .dashboardSection h2 {
+  color: var(--color-gray100);
+  padding: 8px 0;
+  margin-bottom: 20px;
+}
+.myDashboardMain .dashboardSection .emptyDashboard {
+  background: var(--color-black800);
+  border: 1px solid var(--color-gray700);
+  border-radius: 30px;
+  text-align: center;
+  min-width: 332px;
+}
+.myDashboardMain .dashboardSection .emptyDashboard > p {
+  padding-top: 26px;
+  color: var(--color-gray400);
+}
+.myDashboardMain .dashboardSection .emptyDashboard button {
+  background: var(--color-gray900);
+  border: none;
+  border-radius: 100px;
+  width: 107px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto;
+  gap: 4px;
+  color: var(--color-gray100);
+  cursor: pointer;
+}
+.myDashboardMain .dashboardSection .emptyDashboard button > img {
+  filter: invert(95%) sepia(32%) saturate(127%) hue-rotate(182deg)
+    brightness(87%) contrast(95%);
+}
+.myDashboardMain .dashboardSection:nth-of-type(1) .emptyDashboard {
+  padding: 40px 0;
+}
+.myDashboardMain .dashboardSection:nth-of-type(1) .emptyDashboard > p {
+  padding-bottom: 20px;
+}
+.myDashboardMain .dashboardSection:nth-of-type(2) .emptyDashboard {
+  padding: 70px 0;
+}
+
+/* Tablet */
+@media (max-width: 774px) {
+  .myDashboardMain {
+    padding: 0 30px;
+  }
+  .myDashboardMain .dashboardSection h2 {
+    margin-bottom: 10px;
+  }
+  .myDashboardMain .dashboardSection:nth-of-type(1) .emptyDashboard > img {
+    width: 65px;
+    height: 55px;
+  }
+  .myDashboardMain .dashboardSection:nth-of-type(2) .emptyDashboard > img {
+    width: 65px;
+    height: 60px;
+  }
+  .myDashboardMain .dashboardSection {
+    padding-bottom: 20px;
+  }
+}
+
+/* Mobile */
+@media (max-width: 375px) {
+  .myDashboardMain {
+    padding: 0 20px;
+  }
+  .myDashboardMain .dashboardSection:nth-of-type(1) .emptyDashboard > img {
+    width: 60px;
+    height: 60px;
+  }
+  .myDashboardMain .dashboardSection:nth-of-type(2) .emptyDashboard > img {
+    width: 60px;
+    height: 60px;
+  }
+}


### PR DESCRIPTION
## 📝 작업 내용

> 나의 대시보드 데이터 없는 화면

## 📷 스크린샷 (선택)
<img width="1920" height="1081" alt="나의대시보드" src="https://github.com/user-attachments/assets/14b83be1-4486-4fa7-93ee-209e138dde47" />
<img width="744" height="1071" alt="나의대시보드태블릿" src="https://github.com/user-attachments/assets/03fc2789-10c7-4f5e-8da7-055b2812bbcf" />
<img width="375" height="756" alt="나의대시보드모바일" src="https://github.com/user-attachments/assets/149c5489-22b9-4a36-8dd6-8c6ef72ec52b" />


## 🧐 해결해야 하는 문제 (선택)
모바일 에서 `NavigationBar` 컴포넌트에서 버튼을 클릭해 `DashboardSideBar` 컴포넌트가 나오는 작업에 관해 고민이네요.