### PR TITLE
[#105] Textarea 컴포넌트 사이즈 옵션 추가 (lg, md, auto) 및 스크롤바 디자인 수정

### DIFF
--- a/src/components/input/textarea.module.css
+++ b/src/components/input/textarea.module.css
@@ -50,3 +50,14 @@
   color: var(--color-gray400);
   border: none;
 }
+
+.textarea::-webkit-scrollbar {
+  width: 6px;
+}
+
+.textarea::-webkit-scrollbar-thumb {
+  background: var(--color-gray600);
+  border-radius: 100px;
+  cursor: default;
+  min-height: 40px;
+}

--- a/src/components/input/textarea.module.css
+++ b/src/components/input/textarea.module.css
@@ -1,20 +1,33 @@
 .textarea {
-  width: 100%;
-  max-width: 290px;
-  border-radius: 14px;
-  height: 140px;
   background-color: var(--color-black800);
   color: var(--color-gray300);
   resize: none;
-  border-radius: 14px;
   box-shadow: 0 0 0 1px var(--color-gray700) inset;
   border: none;
   padding: 20px;
   outline: none;
 }
 
+.lg {
+  width: 290px;
+  height: 160px;
+  border-radius: 14px;
+}
+
+.md {
+  width: 290px;
+  height: 120px;
+  border-radius: 12px;
+}
+
+.auto {
+  width: 100%;
+  height: 160px;
+  border-radius: 14px;
+}
+
 @media (max-width: 375px) {
-  .textarea {
+  .auto {
     height: 120px;
     border-radius: 12px;
   }

--- a/src/components/input/textarea.tsx
+++ b/src/components/input/textarea.tsx
@@ -2,13 +2,26 @@ import Typography from "@/components/typography";
 import { TextareaHTMLAttributes } from "react";
 import styles from "./textarea.module.css";
 
-interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export enum TextareaSize {
+  Large = "lg",
+  Medium = "md",
+  Auto = "auto",
+}
 
-export default function Textarea({ className, ...props }: TextareaProps) {
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  size?: TextareaSize;
+}
+
+export default function Textarea({
+  size = TextareaSize.Auto,
+  className,
+  ...props
+}: TextareaProps) {
   return (
     <textarea
       {...props}
-      className={`${styles.textarea} 
+      className={`${styles.textarea}
+                  ${styles[size]} 
                   ${Typography.lgMedium} 
                   ${className ?? ""} `}
     />

--- a/src/pages/test-components/index.tsx
+++ b/src/pages/test-components/index.tsx
@@ -10,7 +10,7 @@ import { getDashboards } from "@/components/dashboard-side-bar/api/dashboard";
 import DashboardSideBar from "@/components/dashboard-side-bar/dashboard-side-bar";
 import Dialog from "@/components/dialog";
 import Input, { InputSize, InputVariant } from "@/components/input/input";
-import Textarea from "@/components/input/textarea";
+import Textarea, { TextareaSize } from "@/components/input/textarea";
 import Modal from "@/components/modal";
 import Profile from "@/components/profile/profile";
 import { ProfileSize } from "@/components/profile/profile-size";
@@ -398,10 +398,20 @@ function TextareaBox() {
   return (
     <div>
       <div style={{ marginBottom: "8px" }}>
-        <Textarea placeholder="Text" />
+        <Textarea placeholder="Large" size={TextareaSize.Large} />
       </div>
       <div style={{ marginBottom: "8px" }}>
-        <Textarea placeholder="Disabled" disabled />
+        <Textarea placeholder="Medium" size={TextareaSize.Medium} />
+      </div>
+      <div style={{ marginBottom: "8px" }}>
+        <Textarea placeholder="Auto" size={TextareaSize.Auto} />
+      </div>
+      <div style={{ marginBottom: "8px" }}>
+        <Textarea
+          placeholder="Disabled, Large"
+          size={TextareaSize.Large}
+          disabled
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## 📝 작업 내용

- Textarea 에 사이즈를 받는 옵션 추가 (Textarea.Auto/Large/Medium)
- 스크롤바 디자인 피그마 시안에 맞게 수정

## 📷 스크린샷 (선택)

<img width="880" height="591" alt="image" src="https://github.com/user-attachments/assets/ab8aefca-d31c-4a20-88aa-9ef655fe40f7" />

## 🧐 해결해야 하는 문제 (선택)

- 스크롤바 오른쪽에 여백 넣기

## 👀 새로 알게 된 내용 (선택)

공통컴포넌트의 크기를 동적으로도 구현할수 있게 해야한다는점

## 💬 리뷰어에게 남길 말 (선택)

참솔님이 알려주신대로 wrapper를 만들어서 여백을 넣으려 해봤는데 하다가 머리가 고장나버려서
일단 로그인, 회원가입 먼저 구현하겠습니다.
