### PR TITLE
[#105] 공통 api 토큰 모듈 및 로그인 기능 개발

### DIFF
--- a/src/features/auth/apis/login.ts
+++ b/src/features/auth/apis/login.ts
@@ -1,0 +1,27 @@
+import { axiosInstance } from "@/services/api-client";
+
+interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+interface LoginSuccess {
+  user: {
+    id: number;
+    email: string;
+    nickname: string;
+    profileImageUrl: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  accessToken: string;
+  refreshToken: string;
+}
+interface LoginError {
+  message: string;
+}
+
+export const login = async (body: LoginRequest): Promise<LoginSuccess> => {
+  const res = await axiosInstance.post<LoginSuccess>("/auth/login", body);
+  return res.data;
+};

--- a/src/features/auth/apis/login.ts
+++ b/src/features/auth/apis/login.ts
@@ -15,10 +15,6 @@ interface LoginSuccess {
     updatedAt: string;
   };
   accessToken: string;
-  refreshToken: string;
-}
-interface LoginError {
-  message: string;
 }
 
 export const login = async (body: LoginRequest): Promise<LoginSuccess> => {

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -10,25 +10,25 @@ import { ChangeEvent, useEffect, useState } from "react";
 import styles from "./index.module.css";
 
 export default function LoginPage() {
-  const [id, setId] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
-  const [idErrorMessage, setIdErrorMessage] = useState("");
+  const [emailErrorMessage, setEmailErrorMessage] = useState("");
   const [passwordErrorMessage, setPasswordErrorMessage] = useState("");
   const [isLoginButtonDisabled, setIsLoginButtonDisabled] = useState(true);
-  const onIdChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setId(e.target.value);
+  const onEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setEmail(e.target.value);
   };
 
-  const onIdBlur = () => {
-    if (!id) {
-      setIdErrorMessage("");
+  const onEmailBlur = () => {
+    if (!email) {
+      setEmailErrorMessage("");
       return;
     }
 
-    if (validateEmail(id)) {
-      setIdErrorMessage("");
+    if (validateEmail(email)) {
+      setEmailErrorMessage("");
     } else {
-      setIdErrorMessage("이메일 형식으로 작성해주세요");
+      setEmailErrorMessage("이메일 형식으로 작성해주세요");
     }
   };
 
@@ -49,8 +49,8 @@ export default function LoginPage() {
     }
   };
 
-  const onIdFocus = () => {
-    setIdErrorMessage("");
+  const onEmailFocus = () => {
+    setEmailErrorMessage("");
   };
 
   const onPasswordFocus = () => {
@@ -63,10 +63,13 @@ export default function LoginPage() {
 
   useEffect(() => {
     const isFormValid =
-      !!id && validateEmail(id) && !!password && validatePassword(password);
+      !!email &&
+      validateEmail(email) &&
+      !!password &&
+      validatePassword(password);
 
     setIsLoginButtonDisabled(!isFormValid);
-  }, [id, password]);
+  }, [email, password]);
 
   return (
     <main className={styles.main}>
@@ -83,11 +86,11 @@ export default function LoginPage() {
               variant={InputVariant.Default}
               size={InputSize.Auto}
               placeholder="아이디를 입력해주세요"
-              onChange={onIdChange}
-              onBlur={onIdBlur}
-              errorMessage={idErrorMessage}
-              value={id}
-              onFocus={onIdFocus}
+              onChange={onEmailChange}
+              onBlur={onEmailBlur}
+              errorMessage={emailErrorMessage}
+              value={email}
+              onFocus={onEmailFocus}
             />
             <p>비밀번호</p>
             <Input

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -6,9 +6,12 @@ import Input, { InputSize, InputVariant } from "@/components/input/input";
 import Typography from "@/components/typography";
 import { login } from "@/features/auth/apis/login";
 import { useDialog } from "@/hooks/use-dialog";
+import { getApiErrorMessage } from "@/services/api-error";
+import { AuthStorage } from "@/services/auth-storage";
 import { validateEmail, validatePassword } from "@/utils/validator";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import styles from "./index.module.css";
 
@@ -18,6 +21,8 @@ export default function LoginPage() {
   const [emailErrorMessage, setEmailErrorMessage] = useState("");
   const [passwordErrorMessage, setPasswordErrorMessage] = useState("");
   const [isLoginButtonDisabled, setIsLoginButtonDisabled] = useState(true);
+  const [dialogMessage, setDialogMessage] = useState("");
+  const router = useRouter();
   const DIALOG_KEY = "DIALOG_SAMPLE";
   const { isShowDialog, openDialog } = useDialog({
     key: DIALOG_KEY,
@@ -68,7 +73,11 @@ export default function LoginPage() {
     e.preventDefault();
     try {
       const data = await login({ email, password });
+      AuthStorage.setToken(data.accessToken);
+      router.push("/mydashboard");
     } catch (error: any) {
+      const msg = getApiErrorMessage(error, "로그인에 실패했습니다.");
+      setDialogMessage(msg);
       openDialog(true);
     } finally {
     }
@@ -143,7 +152,7 @@ export default function LoginPage() {
       {isShowDialog && (
         <Dialog
           dialogKey={DIALOG_KEY}
-          message="비밀번호가 일치하지 않습니다."
+          message={dialogMessage}
           onConfirm={() => openDialog(false)}
         />
       )}

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,12 +1,15 @@
 import LoginImg from "@/assets/images/login-main.png";
 import LogoImg from "@/assets/images/taskify-logo.svg";
 import Button, { ButtonSize, ButtonVariant } from "@/components/button/button";
+import Dialog from "@/components/dialog";
 import Input, { InputSize, InputVariant } from "@/components/input/input";
 import Typography from "@/components/typography";
+import { login } from "@/features/auth/apis/login";
+import { useDialog } from "@/hooks/use-dialog";
 import { validateEmail, validatePassword } from "@/utils/validator";
 import Image from "next/image";
 import Link from "next/link";
-import { ChangeEvent, useEffect, useState } from "react";
+import { ChangeEvent, FormEvent, useEffect, useState } from "react";
 import styles from "./index.module.css";
 
 export default function LoginPage() {
@@ -15,6 +18,10 @@ export default function LoginPage() {
   const [emailErrorMessage, setEmailErrorMessage] = useState("");
   const [passwordErrorMessage, setPasswordErrorMessage] = useState("");
   const [isLoginButtonDisabled, setIsLoginButtonDisabled] = useState(true);
+  const DIALOG_KEY = "DIALOG_SAMPLE";
+  const { isShowDialog, openDialog } = useDialog({
+    key: DIALOG_KEY,
+  });
   const onEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
   };
@@ -57,8 +64,14 @@ export default function LoginPage() {
     setPasswordErrorMessage("");
   };
 
-  const onSubmit = () => {
-    // TODO: 추후에 Api 요청 및 로그인 로직 추가
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    try {
+      const data = await login({ email, password });
+    } catch (error: any) {
+      openDialog(true);
+    } finally {
+    }
   };
 
   useEffect(() => {
@@ -110,6 +123,7 @@ export default function LoginPage() {
               size={ButtonSize.Large}
               isWidthFull
               disabled={isLoginButtonDisabled}
+              onClick={handleSubmit}
             >
               로그인
             </Button>
@@ -126,6 +140,13 @@ export default function LoginPage() {
       <section className={styles.rightSection}>
         <Image src={LoginImg} alt="로그인 메인" width={900} height={920} />
       </section>
+      {isShowDialog && (
+        <Dialog
+          dialogKey={DIALOG_KEY}
+          message="비밀번호가 일치하지 않습니다."
+          onConfirm={() => openDialog(false)}
+        />
+      )}
     </main>
   );
 }

--- a/src/pages/test-components/index.tsx
+++ b/src/pages/test-components/index.tsx
@@ -20,11 +20,13 @@ import SheetSection from "@/components/sheet/sheet-section";
 import Typography from "@/components/typography";
 import { CommonSize } from "@/constants/common/common-size";
 import { ProfileRandomColor } from "@/constants/profile-random-color";
+import { login } from "@/features/auth/apis/login";
 import ImageInput from "@/features/edit-task/components/image-input";
 import { useAlert } from "@/hooks/use-alert";
 import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
 import { useSheet } from "@/hooks/use-sheet";
+import { AuthStorage } from "@/services/auth-storage";
 import { ReactNode, useEffect, useState } from "react";
 
 function Section({ title, children }: { title: string; children: ReactNode }) {
@@ -551,6 +553,29 @@ function ProfileSample() {
   );
 }
 
+async function setTokenTest() {
+  const email = "dog3027@Naver.com";
+  const password = "11111111";
+  try {
+    const data = await login({ email, password });
+    AuthStorage.setToken(data.accessToken);
+  } catch (error: any) {
+  } finally {
+  }
+}
+
+function TokenTest() {
+  return (
+    <div>
+      <Button onClick={setTokenTest}>인증된 토큰 발급</Button>
+      <Button onClick={AuthStorage.clear}>토큰 지우기</Button>
+      <Button onClick={() => AuthStorage.setToken("fake token")}>
+        이상한 토큰 넣기
+      </Button>
+    </div>
+  );
+}
+
 export default function Page() {
   const [dashboards, setDashboards] = useState<any[]>([]);
   useEffect(() => {
@@ -622,6 +647,9 @@ export default function Page() {
       </Section>
       <Section title="profile">
         <ProfileSample />
+      </Section>
+      <Section title="token test">
+        <TokenTest />
       </Section>
     </main>
   );

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -1,10 +1,8 @@
 import axios from "axios";
 
-const axiosInstance = axios.create({
+export const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE,
   headers: {
     "Content-Type": "application/json",
   },
 });
-
-export default axiosInstance;

--- a/src/services/api-client.ts
+++ b/src/services/api-client.ts
@@ -1,4 +1,6 @@
+import { AuthStorage } from "@/services/auth-storage";
 import axios from "axios";
+import Router from "next/router";
 
 export const axiosInstance = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_BASE,
@@ -6,3 +8,33 @@ export const axiosInstance = axios.create({
     "Content-Type": "application/json",
   },
 });
+
+axiosInstance.interceptors.request.use(
+  (config) => {
+    const token = AuthStorage.getToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+axiosInstance.interceptors.response.use(
+  (response) => response,
+
+  async (error) => {
+    const status = error?.response?.status;
+
+    if (status === 401) {
+      AuthStorage.clear();
+      Router.push("/login");
+    }
+
+    //TODO: 다른 status 시 동작 추가
+
+    return Promise.reject(error);
+  }
+);

--- a/src/services/api-error.ts
+++ b/src/services/api-error.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+export function getApiErrorMessage(
+  error: unknown,
+  fallback = "요청에 실패했습니다."
+) {
+  if (axios.isAxiosError(error)) {
+    const errorMessage = (
+      error.response?.data as { message?: string } | undefined
+    )?.message;
+    if (typeof errorMessage === "string" && errorMessage.trim().length > 0)
+      return errorMessage;
+  }
+  return fallback;
+}

--- a/src/services/auth-storage.ts
+++ b/src/services/auth-storage.ts
@@ -1,0 +1,23 @@
+const ACCESS_TOKEN_KEY = "accessToken";
+
+export const AuthStorage = {
+  setToken(token: string) {
+    try {
+      localStorage.setItem(ACCESS_TOKEN_KEY, token);
+    } catch {}
+  },
+
+  getToken(): string | null {
+    try {
+      return localStorage.getItem(ACCESS_TOKEN_KEY);
+    } catch {
+      return null;
+    }
+  },
+
+  clear() {
+    try {
+      localStorage.removeItem(ACCESS_TOKEN_KEY);
+    } catch {}
+  },
+};


### PR DESCRIPTION
## 📝 작업 내용

- Api 요청시 헤더에 토큰 같이 날리도록 수정
- 서버로부터 401 에러 받을시 /login 페이지로 리다이렉트
- 로그인시 /mydashboard 로 이동
- 비밀번호, 이메일 틀렸을시 각 케이스에 따른 에러메세지 출력
- api 요청 에러 메세지 반환하는 함수 추가

## 📷 스크린샷 (선택)


https://github.com/user-attachments/assets/9e9f0109-611b-4b3d-9037-e100b3932c4c



## 🧐 해결해야 하는 문제 (선택)

- 추가로 생각해야할 놓치고 있는 로그인 케이스가 있는지 고민
- 서버 각 에러 응답에 따른 interceptors 처리를 어떻게 해야할지? (404, 400, 403 등등)
- 다시한번 파일구조 고민.. 
services 안에 apis폴더를 하나 만들고  api-client, api-error, auth-storage 를 넣어야할까요?

## 👀 새로 알게 된 내용 (선택)

처음 구현해보는거라 전부 새로움.
- axios 통신
- 토큰 발급, 처리

## 💬 리뷰어에게 남길 말 (선택)

서버로 모든 요청 날릴때 토큰이있으면 같이 날리도록 해놓는게 맞을까요 ??
