### PR TITLE
[#98] ColumnEditSheet 개발

### DIFF
--- a/src/components/sheet/index.tsx
+++ b/src/components/sheet/index.tsx
@@ -87,7 +87,6 @@ export default function Sheet({
   };
 
   const handleActionClick = () => {
-    openSheet(false);
     onAction?.();
   };
 

--- a/src/components/sheet/index.tsx
+++ b/src/components/sheet/index.tsx
@@ -17,10 +17,11 @@ export enum SheetActionType {
 
 interface SheetActionProps {
   type: SheetActionType;
+  disabled?: boolean;
   onClick: MouseEventHandler<HTMLButtonElement>;
 }
 
-function SheetAction({ type, onClick }: SheetActionProps) {
+function SheetAction({ type, onClick, disabled }: SheetActionProps) {
   const { isMobile } = useResponsive();
 
   const buttonVariant = useMemo(() => {
@@ -47,6 +48,7 @@ function SheetAction({ type, onClick }: SheetActionProps) {
       size={buttonSize}
       isWidthFull
       onClick={handleClick}
+      disabled={disabled}
     >
       {type}
     </Button>
@@ -57,6 +59,7 @@ interface Props {
   sheetKey: string;
   title: string;
   actionType: SheetActionType;
+  canSubmit?: boolean;
   children: ReactNode;
   onCancel?: () => void;
   onAction?: () => void;
@@ -66,6 +69,7 @@ export default function Sheet({
   sheetKey,
   title,
   actionType,
+  canSubmit = true,
   children,
   onCancel,
   onAction,
@@ -107,7 +111,11 @@ export default function Sheet({
               type={SheetActionType.Cancel}
               onClick={handleCancelClick}
             />
-            <SheetAction type={actionType} onClick={handleActionClick} />
+            <SheetAction
+              type={actionType}
+              onClick={handleActionClick}
+              disabled={!canSubmit}
+            />
           </div>
         </form>
       </div>

--- a/src/features/column/components/column-edit-sheet.tsx
+++ b/src/features/column/components/column-edit-sheet.tsx
@@ -1,0 +1,67 @@
+import Input, { InputSize } from "@/components/input/input";
+import Sheet, { SheetActionType } from "@/components/sheet";
+import SheetSection from "@/components/sheet/sheet-section";
+import { useSheet } from "@/hooks/use-sheet";
+import { Column } from "@/types/column";
+import { ChangeEvent, useState } from "react";
+
+interface Props {
+  sheetKey: string;
+  column?: Column;
+  usedTitles?: string[];
+  onSubmit: (title: string) => void;
+}
+
+export default function ColumnEditSheet({
+  sheetKey,
+  column,
+  usedTitles = [],
+  onSubmit,
+}: Props) {
+  const { openSheet } = useSheet({ key: sheetKey });
+  const [title, setTitle] = useState<string>(column?.title ?? "");
+  const [errorMessage, setErrorMessage] = useState<string | undefined>();
+
+  const sheetTitle = column ? "칼럼 관리" : "새 칼럼 생성";
+  const actionType = column ? SheetActionType.Modify : SheetActionType.Create;
+  const canSubmit = title.length > 0 && column?.title !== title;
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setErrorMessage(undefined);
+    setTitle(event.target.value);
+  };
+
+  const handleSubmit = async () => {
+    if (usedTitles.includes(title)) {
+      setErrorMessage("중복된 칼럼명입니다.");
+      return;
+    }
+
+    try {
+      onSubmit(title);
+      openSheet(false);
+    } catch (error) {
+      setErrorMessage((error as Error).message);
+    }
+  };
+
+  return (
+    <Sheet
+      sheetKey={sheetKey}
+      title={sheetTitle}
+      actionType={actionType}
+      canSubmit={canSubmit}
+      onAction={handleSubmit}
+    >
+      <SheetSection title="이름">
+        <Input
+          value={title}
+          placeholder="칼럼 이름"
+          size={InputSize.Auto}
+          errorMessage={errorMessage}
+          onChange={handleTitleChange}
+        />
+      </SheetSection>
+    </Sheet>
+  );
+}

--- a/src/pages/test-components/index.tsx
+++ b/src/pages/test-components/index.tsx
@@ -657,9 +657,14 @@ function SheetSample() {
 }
 
 function ColumnEditSheetSample() {
-  const SHEET_KEY = "COLUMN_EDIT_SHEET_SAMPLE";
-  const { isShowSheet, openSheet } = useSheet({
-    key: SHEET_KEY,
+  const SHEET_KEY1 = "COLUMN_EDIT_SHEET_SAMPLE_1";
+  const { isShowSheet: isShowSheet1, openSheet: openSheet1 } = useSheet({
+    key: SHEET_KEY1,
+  });
+
+  const SHEET_KEY2 = "COLUMN_EDIT_SHEET_SAMPLE_2";
+  const { isShowSheet: isShowSheet2, openSheet: openSheet2 } = useSheet({
+    key: SHEET_KEY2,
   });
 
   const handleSubmit = (title: string) => {
@@ -669,21 +674,21 @@ function ColumnEditSheetSample() {
   return (
     <>
       <div>
-        <button onClick={() => openSheet(true)}>Open Sheet</button>
-        {isShowSheet && (
+        <button onClick={() => openSheet1(true)}>Open Sheet</button>
+        {isShowSheet1 && (
           <ColumnEditSheet
-            sheetKey={SHEET_KEY}
+            sheetKey={SHEET_KEY1}
             usedTitles={["To do", "Progress", "Done"]}
             onSubmit={handleSubmit}
           />
         )}
         <div>
-          <button onClick={() => openSheet(true)}>
+          <button onClick={() => openSheet2(true)}>
             Open Sheet with Column
           </button>
-          {isShowSheet && (
+          {isShowSheet2 && (
             <ColumnEditSheet
-              sheetKey={SHEET_KEY}
+              sheetKey={SHEET_KEY2}
               column={{
                 id: 1,
                 title: "In Progress",

--- a/src/pages/test-components/index.tsx
+++ b/src/pages/test-components/index.tsx
@@ -7,7 +7,6 @@ import ColorChip from "@/components/chips/chip-color/chips-color";
 import { ColorFrameSize } from "@/components/chips/color-frame/color-frame-size";
 import { Color } from "@/components/color";
 import ColorPalette from "@/components/color-palette/color-palette";
-import { getDashboards } from "@/features/dashboard-side-bar/api/dashboard";
 import DashboardSideBar from "@/components/dashboard-side-bar/dashboard-side-bar";
 import Dialog from "@/components/dialog";
 import Input, { InputSize, InputVariant } from "@/components/input/input";
@@ -25,6 +24,7 @@ import { ProfileRandomColor } from "@/constants/profile-random-color";
 import Dropdown, { DropdownOption } from "@/features/card/components/dropdown";
 import ImageInput from "@/features/card/components/image-input";
 import TagInput from "@/features/card/components/tag-input";
+import ColumnEditSheet from "@/features/column/components/column-edit-sheet";
 import { useAlert } from "@/hooks/use-alert";
 import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
@@ -515,7 +515,7 @@ function BadgeSample() {
 function ColorPaletteSample() {
   const sizes = Object.values(ColorFrameSize);
   const [selectedColors, setSelectedColors] = useState<string[]>(
-    sizes.map(() => ""),
+    sizes.map(() => "")
   );
 
   const handleSelect = (index: number, color: string) => {
@@ -656,6 +656,51 @@ function SheetSample() {
   );
 }
 
+function ColumnEditSheetSample() {
+  const SHEET_KEY = "COLUMN_EDIT_SHEET_SAMPLE";
+  const { isShowSheet, openSheet } = useSheet({
+    key: SHEET_KEY,
+  });
+
+  const handleSubmit = (title: string) => {
+    console.log("Submitted title:", title);
+  };
+
+  return (
+    <>
+      <div>
+        <button onClick={() => openSheet(true)}>Open Sheet</button>
+        {isShowSheet && (
+          <ColumnEditSheet
+            sheetKey={SHEET_KEY}
+            usedTitles={["To do", "Progress", "Done"]}
+            onSubmit={handleSubmit}
+          />
+        )}
+        <div>
+          <button onClick={() => openSheet(true)}>
+            Open Sheet with Column
+          </button>
+          {isShowSheet && (
+            <ColumnEditSheet
+              sheetKey={SHEET_KEY}
+              column={{
+                id: 1,
+                title: "In Progress",
+                teamId: "18-4",
+                createdAt: "",
+                updatedAt: "",
+              }}
+              usedTitles={["To do", "Progress", "Done"]}
+              onSubmit={handleSubmit}
+            />
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
 function ProfileSample() {
   return (
     <>
@@ -735,6 +780,9 @@ export default function Page() {
       </Section>
       <Section title="Sheet">
         <SheetSample />
+      </Section>
+      <Section title="ColumnEditSheet">
+        <ColumnEditSheetSample />
       </Section>
       <Section title="SideBar">
         <DashboardSideBar dashboards={dashboards} />


### PR DESCRIPTION
## 📝 작업 내용

- 대시보드에서 column을 추가 및 수정할 때 사용하는 sheet 컴포넌트를 개발합니다.

## 📷 스크린샷 (선택)

| 생성 | 수정 | 중복 error |
|--------|--------|--------|
| <img width="624" height="324" alt="image" src="https://github.com/user-attachments/assets/040b7fdc-3562-4595-a6ae-bc0dc18f8e7a" /> | <img width="624" height="324" alt="image" src="https://github.com/user-attachments/assets/7312e230-39b1-41b4-8e42-dc3b93a5d555" /> | <img width="624" height="338" alt="image" src="https://github.com/user-attachments/assets/1ed118ee-7cf9-43e0-952a-c966495c83b6" /> |

## 💬 리뷰어에게 남길 말 (선택)

- `onSubmit` callback의 parameter로 전달되는 값을 사용해서 column 생성/수정 API를 호출하도록 구현하시면 됩니다.
- `onSubmit`에서 `Error`를 throw하면 input의 error message로 설정되도록 구현되어 있습니다. 
- Swagger 문서에 따라 400, 404 error 발생 시 반환되는 error message로 `Error` 객체를 만들어서 throw하면, `Input` 컴포넌트의 error message로 표시할 수 있습니다.