### PR TITLE
[#60] Modal을 열었을 때 배경 화면에서 스크롤되는 문제 수정

### DIFF
--- a/src/hooks/use-modal.tsx
+++ b/src/hooks/use-modal.tsx
@@ -1,5 +1,5 @@
 import { ModalContext } from "@/components/modal/modal-provider";
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 
 const INITIAL_MODAL_STATE = { isMount: false, isOpen: false };
 
@@ -48,6 +48,10 @@ export function useModal({ key }: Props) {
       },
     }));
   };
+
+  useEffect(() => {
+    document.body.style.overflow = isMount ? "hidden" : "auto";
+  }, [isMount]);
 
   return {
     isShowModal: isMount,


### PR DESCRIPTION
## 📝 작업 내용

- `Modal` 컴포넌트가 화면에 표시되었을 때 뒷 배경의 스크롤이 동작하던 문제를 수정합니다.
- `Modal`을 사용하는 `Alert`, `Dialog`, `Sheet` 등 컴포넌트들도 모두 적용됩니다.