### PR TITLE
[#26] CardDetailModal 개선, Modal을 중첩해서 열 때 navigation 처리 추가 등

### DIFF
--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -39,8 +39,6 @@ export default function Modal({
       className = hasNestedModal ? "nested" : styles.close;
     }
 
-    console.log(`Root modalClassName for ${modalKey} : ${className}`);
-
     return classnames(base, className);
   }
 

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,6 +1,6 @@
 import { useModal } from "@/hooks/use-modal";
 import { classnames } from "@/utils/classnames";
-import { MouseEvent, ReactNode } from "react";
+import { MouseEvent, ReactNode, useRef } from "react";
 import { createPortal } from "react-dom";
 import styles from "./modal.module.css";
 
@@ -15,7 +15,53 @@ export default function Modal({
   isFullScreen = false,
   children,
 }: Props) {
-  const { isOpenModal, openModal, onCloseModal } = useModal({ key: modalKey });
+  const { isOpenModal, openModal, onCloseModal, modalStack } = useModal({
+    key: modalKey,
+  });
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const isRootModal = modalStack.length === 0 || modalStack[0] === modalKey;
+
+  function modalClassName() {
+    const base = styles.modal;
+
+    if (!isRootModal) {
+      return classnames(base, styles.transparent);
+    }
+
+    let className;
+    if (isOpenModal) {
+      const modalNode = modalRef.current;
+      const hadNestedModal = modalNode?.className.split(" ").includes("nested");
+      className = hadNestedModal ? "nested" : styles.open;
+    } else {
+      const hasNestedModal = modalStack.length > 1;
+      className = hasNestedModal ? "nested" : styles.close;
+    }
+
+    console.log(`Root modalClassName for ${modalKey} : ${className}`);
+
+    return classnames(base, className);
+  }
+
+  function contentClassName() {
+    const base = classnames(
+      styles.content,
+      isFullScreen ? styles.fullscreen : ""
+    );
+
+    if (isRootModal) {
+      if (isOpenModal) {
+        return base;
+      } else {
+        return modalStack.includes(modalKey)
+          ? styles.closeWithoutAnimation
+          : "";
+      }
+    }
+
+    return classnames(base, isOpenModal ? styles.open : styles.close);
+  }
 
   const handleAnimationEnd = () => {
     if (isOpenModal) return;
@@ -32,20 +78,12 @@ export default function Modal({
 
   const modal = (
     <div
-      className={classnames(
-        styles.modal,
-        isOpenModal ? styles.open : styles.close
-      )}
+      className={modalClassName()}
       onAnimationEnd={handleAnimationEnd}
       onClick={handleClick}
+      ref={modalRef}
     >
-      <div
-        className={classnames(
-          styles.content,
-          isFullScreen ? styles.fullscreen : ""
-        )}
-        onClick={handleContentClick}
-      >
+      <div className={contentClassName()} onClick={handleContentClick}>
         {children}
       </div>
     </div>

--- a/src/components/modal/modal-provider.tsx
+++ b/src/components/modal/modal-provider.tsx
@@ -16,6 +16,8 @@ export interface ModalState {
 interface ContextValue {
   modalState: ModalState | null;
   setModalState: Dispatch<SetStateAction<ModalState | null>>;
+  modalStack: string[];
+  setModalStack: Dispatch<SetStateAction<string[]>>;
 }
 
 export const ModalContext = createContext<ContextValue | null>(null);
@@ -26,9 +28,12 @@ interface Props {
 
 export default function ModalProvider({ children }: Props) {
   const [modalState, setModalState] = useState<ModalState | null>(null);
+  const [modalStack, setModalStack] = useState<string[]>([]);
 
   return (
-    <ModalContext value={{ modalState, setModalState }}>
+    <ModalContext
+      value={{ modalState, setModalState, modalStack, setModalStack }}
+    >
       {children}
     </ModalContext>
   );

--- a/src/components/modal/modal.module.css
+++ b/src/components/modal/modal.module.css
@@ -10,6 +10,10 @@
   justify-content: center;
 }
 
+.transparent {
+  background-color: transparent;
+}
+
 .content {
   background-color: var(--color-modalBackground);
   border-radius: 24px;
@@ -30,7 +34,10 @@
   }
 }
 .open {
-  animation: fadeIn 0.1s ease-out forwards;
+  animation: fadeIn 0.2s ease-out forwards;
+}
+.openWithoutAnimation {
+  opacity: 1;
 }
 
 @keyframes fadeOut {
@@ -42,5 +49,8 @@
   }
 }
 .close {
-  animation: fadeOut 0.1s ease-out forwards;
+  animation: fadeOut 0.15s ease-out forwards;
+}
+.closeWithoutAnimation {
+  opacity: 0;
 }

--- a/src/constants/card/card-status.ts
+++ b/src/constants/card/card-status.ts
@@ -1,5 +1,0 @@
-export enum CardStatus {
-  ToDo,
-  OnProgress,
-  Done,
-}

--- a/src/features/card/components/card-detail-modal.tsx
+++ b/src/features/card/components/card-detail-modal.tsx
@@ -2,6 +2,7 @@ import SampleImage from "@/assets/images/dashboard-gui.png";
 import IconButton from "@/components/button/icon-button";
 import Badge from "@/components/chips/badge/badge";
 import { Color } from "@/components/color";
+import Dialog from "@/components/dialog";
 import MoreIcon from "@/components/icon/more-icon";
 import XmarkIcon from "@/components/icon/xmark-icon";
 import Modal from "@/components/modal";
@@ -10,6 +11,7 @@ import { ProfileSize } from "@/components/profile/profile-size";
 import Typography from "@/components/typography";
 import { Direction, Menu, MenuItem } from "@/features/card/components/menu";
 import { getComments } from "@/features/comment/apis/comment";
+import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
 import { useResponsive } from "@/hooks/use-responsive";
 import { Card } from "@/types/card";
@@ -229,14 +231,19 @@ export default function CardDetailModal({
   const { openModal } = useModal({ key: modalKey });
   const { isDesktop, isMobile } = useResponsive();
 
+  // TODO: CardEditSheet로 교체
+  const { isShowDialog, openDialog } = useDialog({
+    key: "dialog-from-card-detail-modal",
+  });
+
   const handleEdit = () => {
     // TODO: Move to edit modal
-    console.log("Edit card");
+    openDialog(true);
   };
 
   const handleDelete = () => {
     // TODO: Delete card
-    console.log("Delete card");
+    openDialog(true);
   };
 
   const handleClose = () => {
@@ -266,6 +273,12 @@ export default function CardDetailModal({
           />
         )}
       </div>
+      {isShowDialog && (
+        <Dialog
+          dialogKey="dialog-from-card-detail-modal"
+          message="Dialog from CardDetailModal"
+        />
+      )}
     </Modal>
   );
 }

--- a/src/features/card/components/card-detail-modal.tsx
+++ b/src/features/card/components/card-detail-modal.tsx
@@ -8,7 +8,6 @@ import Modal from "@/components/modal";
 import Profile from "@/components/profile/profile";
 import { ProfileSize } from "@/components/profile/profile-size";
 import Typography from "@/components/typography";
-import { CardStatus } from "@/constants/card/card-status";
 import { Direction, Menu, MenuItem } from "@/features/card/components/menu";
 import { getComments } from "@/features/comment/apis/comment";
 import { useModal } from "@/hooks/use-modal";
@@ -22,12 +21,6 @@ import { formatDueDate } from "../../../utils/date-formatter";
 import CommentInput from "../../comment/components/comment-input";
 import CommentList from "../../comment/components/comment-list";
 import styles from "./card-detail-modal.module.css";
-
-export const STATUS_TITLE = {
-  [CardStatus.ToDo]: "To Do",
-  [CardStatus.OnProgress]: "On Progress",
-  [CardStatus.Done]: "Done",
-} as const;
 
 function Actions({ onClose }: { onClose: () => void }) {
   const handleEdit = () => {
@@ -65,24 +58,53 @@ function InfoContent({ children }: { children: ReactNode }) {
   return <div className={Typography.lgMedium}>{children}</div>;
 }
 
+function ProjectInfo({
+  dashboardTitle,
+  columnTitle,
+}: {
+  dashboardTitle: string;
+  columnTitle: string;
+}) {
+  return (
+    <>
+      <InfoTitle>프로젝트</InfoTitle>
+      <InfoContent>
+        {dashboardTitle} / {columnTitle}
+      </InfoContent>
+    </>
+  );
+}
+
 function AssigneeInfo({ name }: { name: string }) {
   return (
-    <div className={classnames(styles.assigneeInfo, Typography.lgMedium)}>
-      <Profile size={ProfileSize.XSmall} name={name.slice(1)} />
-      <span>{name}</span>
-    </div>
+    <>
+      <InfoTitle>담당자</InfoTitle>
+      <div className={classnames(styles.assigneeInfo, Typography.lgMedium)}>
+        <Profile size={ProfileSize.XSmall} name={name.slice(1)} />
+        <span>{name}</span>
+      </div>
+    </>
+  );
+}
+
+function DueDateInfo({ dueDate }: { dueDate: string }) {
+  return (
+    <>
+      <InfoTitle>마감일</InfoTitle>
+      <InfoContent>{formatDueDate(dueDate)}</InfoContent>
+    </>
   );
 }
 
 function Sidebar({
   dashboardTitle,
-  cardStatus,
+  columnTitle,
   assignee,
   dueDate,
   onClose,
 }: {
   dashboardTitle: string;
-  cardStatus: CardStatus;
+  columnTitle: string;
   assignee: string;
   dueDate: string;
   onClose: () => void;
@@ -93,18 +115,16 @@ function Sidebar({
         <Actions onClose={onClose} />
       </header>
       <section className={styles.sidebarSection}>
-        <InfoTitle>프로젝트</InfoTitle>
-        <InfoContent>
-          {dashboardTitle} / {STATUS_TITLE[cardStatus]}
-        </InfoContent>
+        <ProjectInfo
+          dashboardTitle={dashboardTitle}
+          columnTitle={columnTitle}
+        />
       </section>
       <section className={classnames(styles.sidebarSection, styles.divider)}>
-        <InfoTitle>담당자</InfoTitle>
         <AssigneeInfo name={assignee} />
       </section>
       <section className={classnames(styles.sidebarSection, styles.divider)}>
-        <InfoTitle>마감일</InfoTitle>
-        <InfoContent>{formatDueDate(dueDate)}</InfoContent>
+        <DueDateInfo dueDate={dueDate} />
       </section>
     </div>
   );
@@ -113,10 +133,12 @@ function Sidebar({
 function Main({
   card,
   dashboardTitle,
+  columnTitle,
   onClose,
 }: {
   card: Card;
   dashboardTitle: string;
+  columnTitle: string;
   onClose: () => void;
 }) {
   const [comments, setComments] = useState<Comment[]>([]);
@@ -165,14 +187,12 @@ function Main({
         </article>
         {isDesktop || (
           <div className={styles.info}>
-            <InfoTitle>프로젝트</InfoTitle>
-            <InfoContent>
-              {dashboardTitle} / {STATUS_TITLE[card.columnId as CardStatus]}
-            </InfoContent>
-            <InfoTitle>담당자</InfoTitle>
+            <ProjectInfo
+              dashboardTitle={dashboardTitle}
+              columnTitle={columnTitle}
+            />
             <AssigneeInfo name={card.assignee.nickname} />
-            <InfoTitle>마감일</InfoTitle>
-            <InfoContent>{formatDueDate(card.dueDate)}</InfoContent>
+            <DueDateInfo dueDate={card.dueDate} />
           </div>
         )}
         <div className={styles.comments}>
@@ -191,12 +211,14 @@ interface Props {
   modalKey: string;
   card: Card;
   dashboardTitle: string;
+  columnTitle: string;
 }
 
 export default function CardDetailModal({
   modalKey,
   card,
   dashboardTitle,
+  columnTitle,
 }: Props) {
   const { openModal } = useModal({ key: modalKey });
   const { isDesktop, isMobile } = useResponsive();
@@ -211,12 +233,13 @@ export default function CardDetailModal({
         <Main
           card={card}
           dashboardTitle={dashboardTitle}
+          columnTitle={columnTitle}
           onClose={handleClose}
         />
         {isDesktop && (
           <Sidebar
             dashboardTitle={dashboardTitle}
-            cardStatus={card.columnId as CardStatus}
+            columnTitle={columnTitle}
             assignee={card.assignee.nickname}
             dueDate={card.dueDate}
             onClose={handleClose}

--- a/src/features/card/components/card-detail-modal.tsx
+++ b/src/features/card/components/card-detail-modal.tsx
@@ -22,19 +22,17 @@ import CommentInput from "../../comment/components/comment-input";
 import CommentList from "../../comment/components/comment-list";
 import styles from "./card-detail-modal.module.css";
 
-function Actions({ onClose }: { onClose: () => void }) {
-  const handleEdit = () => {
-    // TODO: Go to edit modal
-  };
+interface ActionsProps {
+  onEdit: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}
 
-  const handleDelete = () => {
-    // TODO: Delete card with modal (additional feature)
-  };
-
+function Actions({ onEdit, onDelete, onClose }: ActionsProps) {
   return (
     <div className={styles.actions}>
       <Menu
-        items={[MenuItem.edit(handleEdit), MenuItem.delete(handleDelete)]}
+        items={[MenuItem.edit(onEdit), MenuItem.delete(onDelete)]}
         direction={Direction.Right}
       >
         <MoreIcon color={Color.Gray300} />
@@ -96,23 +94,26 @@ function DueDateInfo({ dueDate }: { dueDate: string }) {
   );
 }
 
+interface SidebarProps extends ActionsProps {
+  dashboardTitle: string;
+  columnTitle: string;
+  assignee: string;
+  dueDate: string;
+}
+
 function Sidebar({
   dashboardTitle,
   columnTitle,
   assignee,
   dueDate,
+  onEdit,
+  onDelete,
   onClose,
-}: {
-  dashboardTitle: string;
-  columnTitle: string;
-  assignee: string;
-  dueDate: string;
-  onClose: () => void;
-}) {
+}: SidebarProps) {
   return (
     <div className={styles.sidebar}>
       <header className={styles.sidebarHeader}>
-        <Actions onClose={onClose} />
+        <Actions onEdit={onEdit} onDelete={onDelete} onClose={onClose} />
       </header>
       <section className={styles.sidebarSection}>
         <ProjectInfo
@@ -130,17 +131,20 @@ function Sidebar({
   );
 }
 
+interface MainProps extends ActionsProps {
+  card: Card;
+  dashboardTitle: string;
+  columnTitle: string;
+}
+
 function Main({
   card,
   dashboardTitle,
   columnTitle,
+  onEdit,
+  onDelete,
   onClose,
-}: {
-  card: Card;
-  dashboardTitle: string;
-  columnTitle: string;
-  onClose: () => void;
-}) {
+}: MainProps) {
   const [comments, setComments] = useState<Comment[]>([]);
   const { isDesktop } = useResponsive();
 
@@ -171,7 +175,9 @@ function Main({
             )}
           >
             {card.title}
-            {isDesktop || <Actions onClose={onClose} />}
+            {isDesktop || (
+              <Actions onEdit={onEdit} onDelete={onDelete} onClose={onClose} />
+            )}
           </h2>
           <div className={styles.tagsList}>
             {card.tags.map((tag) => (
@@ -223,6 +229,16 @@ export default function CardDetailModal({
   const { openModal } = useModal({ key: modalKey });
   const { isDesktop, isMobile } = useResponsive();
 
+  const handleEdit = () => {
+    // TODO: Move to edit modal
+    console.log("Edit card");
+  };
+
+  const handleDelete = () => {
+    // TODO: Delete card
+    console.log("Delete card");
+  };
+
   const handleClose = () => {
     openModal(false);
   };
@@ -234,6 +250,8 @@ export default function CardDetailModal({
           card={card}
           dashboardTitle={dashboardTitle}
           columnTitle={columnTitle}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
           onClose={handleClose}
         />
         {isDesktop && (
@@ -242,6 +260,8 @@ export default function CardDetailModal({
             columnTitle={columnTitle}
             assignee={card.assignee.nickname}
             dueDate={card.dueDate}
+            onEdit={handleEdit}
+            onDelete={handleDelete}
             onClose={handleClose}
           />
         )}

--- a/src/hooks/use-modal.tsx
+++ b/src/hooks/use-modal.tsx
@@ -7,7 +7,15 @@ interface Props {
   key: string;
 }
 
-export function useModal({ key }: Props) {
+interface UseModalReturn {
+  isShowModal: boolean;
+  isOpenModal: boolean;
+  openModal: (isOpen: boolean) => void;
+  onCloseModal: () => void;
+  modalStack: string[];
+}
+
+export function useModal({ key }: Props): UseModalReturn {
   const contextValue = useContext(ModalContext);
   if (!contextValue) {
     throw new Error("useModal must be used within a ModalProvider");
@@ -90,5 +98,6 @@ export function useModal({ key }: Props) {
     isOpenModal: isOpen,
     openModal,
     onCloseModal: onClose,
+    modalStack,
   };
 }

--- a/src/hooks/use-modal.tsx
+++ b/src/hooks/use-modal.tsx
@@ -1,4 +1,4 @@
-import { ModalContext } from "@/components/modal/modal-provider";
+import { ModalContext, ModalState } from "@/components/modal/modal-provider";
 import { useContext, useEffect } from "react";
 
 const INITIAL_MODAL_STATE = { isMount: false, isOpen: false };
@@ -13,7 +13,7 @@ export function useModal({ key }: Props) {
     throw new Error("useModal must be used within a ModalProvider");
   }
 
-  const { modalState, setModalState } = contextValue;
+  const { modalState, setModalState, modalStack, setModalStack } = contextValue;
 
   const { isMount, isOpen } = modalState
     ? modalState[key] || INITIAL_MODAL_STATE
@@ -21,25 +21,57 @@ export function useModal({ key }: Props) {
 
   const openModal = (isOpen: boolean) => {
     if (isOpen) {
-      setModalState((prev) => ({
-        ...prev,
-        [key]: {
-          isMount: true,
-          isOpen: true,
-        },
-      }));
+      modalStack.push(key);
+      setModalStack([...modalStack]);
+      setModalState((prev) => {
+        const newState: ModalState = {
+          ...prev,
+          [key]: {
+            isMount: true,
+            isOpen: true,
+          },
+        };
+
+        if (modalStack.length > 1) {
+          const prevStackKey = modalStack[modalStack.length - 2];
+          newState[prevStackKey] = {
+            isMount: true,
+            isOpen: false,
+          };
+        }
+
+        return newState;
+      });
     } else {
-      setModalState((prev) => ({
-        ...prev,
-        [key]: {
-          isMount: true,
-          isOpen: false,
-        },
-      }));
+      modalStack.pop();
+      setModalStack([...modalStack]);
+      setModalState((prev) => {
+        const newState: ModalState = {
+          ...prev,
+          [key]: {
+            isMount: true,
+            isOpen: false,
+          },
+        };
+
+        if (modalStack.length > 0) {
+          const prevStackKey = modalStack[modalStack.length - 1];
+          newState[prevStackKey] = {
+            isMount: true,
+            isOpen: true,
+          };
+        }
+
+        return newState;
+      });
     }
   };
 
   const onClose = () => {
+    if (modalStack.includes(key)) {
+      return;
+    }
+
     setModalState((prev) => ({
       ...prev,
       [key]: {

--- a/src/pages/test-components/index.tsx
+++ b/src/pages/test-components/index.tsx
@@ -782,6 +782,7 @@ function CardDetailModalSample() {
           <CardDetailModal
             modalKey={modalKey}
             card={card}
+            columnTitle="Progress"
             dashboardTitle="포트폴리오"
           />
         )}


### PR DESCRIPTION
## 📝 작업 내용

- `CardDetailModal` 코드를 개선하고 사용 방법을 일부 변경합니다.
  - 변경 전 : `columnId`를 prop으로 받아서 사용
  - 변경 후 : `columnTitle`을 직접 받아서 표시하도록 변경
- `CardDetailModal`에서 `CardEditSheet`(구현 예정)를 중첩해서 열 때, 자연스럽게 전환될 수 있도록 navigation을 구현합니다.

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/25ed627b-e3a4-4674-a75d-5e28003abb5e

이후 '수정하기'와 '삭제하기' 메뉴를 클릭할 때 각각 `CardEditSheet`와 `Action`을 표시하도록 구현할 예정입니다.

## 🧐 해결해야 하는 문제 (선택)

- 예상보다 시간을 많이 잡아먹어서 코드를 깨끗하게 작성하지 못했습니다.
- 나중에 여유가 되면 코드를 개선해 보겠습니다.

## 💬 리뷰어에게 남길 말 (선택)

@nidor022

- 대시보드에서 카드를 클릭했을 때 이 modal을 사용하게 될 텐데요. 변경된 부분을 참고해주세요.
- 기존 코드에 연동하면서 불편하거나 구현하는 데 제한되는 부분이 있으면 알려주세요.