### PR TITLE
[#70] 회원가입 페이지 api 연동

### DIFF
--- a/src/constants/signup/dialog-messages.ts
+++ b/src/constants/signup/dialog-messages.ts
@@ -1,0 +1,5 @@
+export const DIALOG_MESSAGES = {
+  SIGNUP_SUCCESS: "가입이 완료되었습니다!",
+  SIGNUP_FAIL: "회원가입에 실패했습니다.",
+  LOGIN_FAIL: "로그인에 실패했습니다.",
+} as const;

--- a/src/features/auth/apis/login.ts
+++ b/src/features/auth/apis/login.ts
@@ -1,11 +1,11 @@
 import axios from "axios";
 
-export interface LoginRequest {
+interface LoginRequest {
   email: string;
   password: string;
 }
 
-export interface LoginResponse {
+interface LoginResponse {
   accessToken: string;
   user: {
     id: number;

--- a/src/features/user/apis/signup.ts
+++ b/src/features/user/apis/signup.ts
@@ -1,0 +1,21 @@
+import axiosInstance from "@/services/axios-instance";
+
+interface SignupRequest {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+interface SignupResponse {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function signup(body: SignupRequest): Promise<SignupResponse> {
+  const response = await axiosInstance.post("/users", body);
+  return response.data;
+}

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -151,11 +151,7 @@ export default function LoginPage() {
         <Image src={LoginImg} alt="로그인 메인" width={900} height={920} />
       </section>
       {isShowDialog && (
-        <Dialog
-          dialogKey={DIALOG_KEY}
-          message={dialogMessage}
-          onConfirm={() => openDialog(false)}
-        />
+        <Dialog dialogKey={DIALOG_KEY} message={dialogMessage} />
       )}
     </main>
   );

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -23,7 +23,7 @@ export default function LoginPage() {
   const [isLoginButtonDisabled, setIsLoginButtonDisabled] = useState(true);
   const router = useRouter();
   const [dialogMessage, setDialogMessage] = useState("");
-  const DIALOG_KEY = "DIALOG_SAMPLE";
+  const DIALOG_KEY = "DIALOG_LOGIN";
   const { isShowDialog, openDialog } = useDialog({
     key: DIALOG_KEY,
   });

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -4,6 +4,7 @@ import Checkbox from "@/components/checkbox";
 import Dialog from "@/components/dialog";
 import Input, { InputSize, InputVariant } from "@/components/input/input";
 import Typography from "@/components/typography";
+import { DIALOG_MESSAGES } from "@/constants/signup/dialog-messages";
 import { signup } from "@/features/user/apis/signup";
 import { useDialog } from "@/hooks/use-dialog";
 import {
@@ -139,13 +140,13 @@ export default function SignupPage() {
   const handleSubmit = async () => {
     try {
       const response = await signup({ email, nickname, password });
-      setDialogMessage("가입이 완료되었습니다!");
-      openDialog(true);
+      setDialogMessage(DIALOG_MESSAGES.SIGNUP_SUCCESS);
     } catch (err) {
       const error = err as AxiosError<{ message?: string }>;
       const message =
-        error.response?.data?.message ?? "회원가입에 실패했습니다.";
+        error.response?.data?.message ?? DIALOG_MESSAGES.SIGNUP_FAIL;
       setDialogMessage(message);
+    } finally {
       openDialog(true);
     }
   };
@@ -234,8 +235,7 @@ export default function SignupPage() {
           dialogKey={DIALOG_KEY}
           message={dialogMessage}
           onConfirm={() => {
-            openDialog(false);
-            if (dialogMessage === "가입이 완료되었습니다!") {
+            if (dialogMessage === DIALOG_MESSAGES.SIGNUP_SUCCESS) {
               router.push("/login");
             }
           }}

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -32,7 +32,7 @@ export default function SignupPage() {
   const [isSignupButtonDisabled, setIsSignupButtonDisabled] = useState(true);
   const router = useRouter();
   const [dialogMessage, setDialogMessage] = useState("");
-  const DIALOG_KEY = "DIALOG_SAMPLE";
+  const DIALOG_KEY = "DIALOG_SIGNUP";
   const { isShowDialog, openDialog } = useDialog({
     key: DIALOG_KEY,
   });
@@ -139,7 +139,6 @@ export default function SignupPage() {
   const handleSubmit = async () => {
     try {
       const response = await signup({ email, nickname, password });
-      console.log(response);
       setDialogMessage("가입이 완료되었습니다!");
       openDialog(true);
     } catch (err) {

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,15 +1,20 @@
 import LogoImg from "@/assets/images/taskify-logo.svg";
 import Button, { ButtonSize, ButtonVariant } from "@/components/button/button";
 import Checkbox from "@/components/checkbox";
+import Dialog from "@/components/dialog";
 import Input, { InputSize, InputVariant } from "@/components/input/input";
 import Typography from "@/components/typography";
+import { signup } from "@/features/user/apis/signup";
+import { useDialog } from "@/hooks/use-dialog";
 import {
   validateEmail,
   validateNickname,
   validatePassword,
 } from "@/utils/validator";
+import { AxiosError } from "axios";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { ChangeEvent, useEffect, useState } from "react";
 import styles from "./index.module.css";
 
@@ -25,6 +30,12 @@ export default function SignupPage() {
     useState("");
   const [hasAgreedCheckbox, setHasAgreedCheckbox] = useState(false);
   const [isSignupButtonDisabled, setIsSignupButtonDisabled] = useState(true);
+  const router = useRouter();
+  const [dialogMessage, setDialogMessage] = useState("");
+  const DIALOG_KEY = "DIALOG_SAMPLE";
+  const { isShowDialog, openDialog } = useDialog({
+    key: DIALOG_KEY,
+  });
 
   const onEmailChange = (e: ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
@@ -125,8 +136,19 @@ export default function SignupPage() {
     setIsSignupButtonDisabled(!isFormValid);
   }, [email, nickname, password, passwordCheck, hasAgreedCheckbox]);
 
-  const onSubmit = () => {
-    // TODO: 추후에 Api 요청 및 회원가입 로직 추가
+  const handleSubmit = async () => {
+    try {
+      const response = await signup({ email, nickname, password });
+      console.log(response);
+      setDialogMessage("가입이 완료되었습니다!");
+      openDialog(true);
+    } catch (err) {
+      const error = err as AxiosError<{ message?: string }>;
+      const message =
+        error.response?.data?.message ?? "회원가입에 실패했습니다.";
+      setDialogMessage(message);
+      openDialog(true);
+    }
   };
 
   return (
@@ -196,6 +218,7 @@ export default function SignupPage() {
             size={ButtonSize.Large}
             isWidthFull
             disabled={isSignupButtonDisabled}
+            onClick={handleSubmit}
           >
             가입하기
           </Button>
@@ -207,6 +230,18 @@ export default function SignupPage() {
           </p>
         </div>
       </div>
+      {isShowDialog && (
+        <Dialog
+          dialogKey={DIALOG_KEY}
+          message={dialogMessage}
+          onConfirm={() => {
+            openDialog(false);
+            if (dialogMessage === "가입이 완료되었습니다!") {
+              router.push("/login");
+            }
+          }}
+        />
+      )}
     </main>
   );
 }


### PR DESCRIPTION
## 📝 작업 내용

회원가입 api 연동

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/75bc2687-cea5-4790-9e04-b9145dcf06fa

## 💬 리뷰어에게 남길 말 (선택)

회원가입 이후 바로 로그인 되는 로직을 추가해볼까 생각중입니다.
