### PR TITLE
[#101] 계정관리 모달창 구현 

### DIFF
--- a/src/components/account-setting-modal/account-setting-modal.module.css
+++ b/src/components/account-setting-modal/account-setting-modal.module.css
@@ -1,0 +1,47 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  color: var(--color-gray300);
+}
+
+.profileImageSection {
+  display: flex;
+  align-items: center;
+}
+
+.profileImage > div > div,
+.profileImage img {
+  width: 120px;
+  height: 120px;
+  object-fit: cover;
+}
+
+.emailSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nicknameSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.passwordSection {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.profileImageButtons {
+  display: flex;
+  gap: 12px;
+  margin-left: 20px;
+}
+
+.invisibleFileInput {
+  display: none;
+}

--- a/src/components/account-setting-modal/index.tsx
+++ b/src/components/account-setting-modal/index.tsx
@@ -1,0 +1,177 @@
+import Button, { ButtonSize, ButtonVariant } from "@/components/button/button";
+import Dialog from "@/components/dialog";
+import Input, { InputSize, InputVariant } from "@/components/input/input";
+import Profile from "@/components/profile/profile";
+import { ProfileSize } from "@/components/profile/profile-size";
+import Sheet, { SheetActionType } from "@/components/sheet";
+import { useAuth } from "@/features/auth/components/auth-provider";
+import { changeUserdata } from "@/features/user/apis/change-userdata";
+import { getMe, GetMeResponse } from "@/features/user/apis/get-me";
+import { useDialog } from "@/hooks/use-dialog";
+import { useModal } from "@/hooks/use-modal";
+import { AxiosError } from "axios";
+import { useEffect, useRef, useState } from "react";
+import styles from "./account-setting-modal.module.css";
+import PasswordChangeModal from "./password-change-modal";
+
+interface AccountSettingModalProps {
+  modalKey: string;
+}
+
+export default function AccountSettingModal({
+  modalKey,
+}: AccountSettingModalProps) {
+  const PASSWORD_CHANGE_MODAL_KEY = "PASSWORD_CHANGE_MODAL";
+  const {
+    isShowModal: isShowPasswordChangeModal,
+    openModal: openPasswordChangeModal,
+  } = useModal({ key: PASSWORD_CHANGE_MODAL_KEY });
+  const [userData, setUserData] = useState<GetMeResponse | null>(null);
+  const [nickname, setNickname] = useState("");
+  const [profileImage, setProfileImage] = useState("");
+  const { isLoadingToken } = useAuth();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const DIALOG_KEY = "DIALOG_CHAGNE_USERDATA";
+  const { isShowDialog, openDialog } = useDialog({
+    key: DIALOG_KEY,
+  });
+  const [dialogMessage, setDialogMessage] = useState("");
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    if (isLoadingToken) return;
+    async function loadUserData() {
+      try {
+        setUserData(await getMe());
+      } catch (error: unknown) {
+        console.error("Load User Data Failed:", error);
+      }
+    }
+    loadUserData();
+  }, [isLoadingToken]);
+
+  useEffect(() => {
+    if (userData) {
+      setNickname(userData.nickname);
+      setProfileImage(userData.profileImageUrl);
+    }
+  }, [userData]);
+
+  const onNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value);
+  };
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const previewUrl = URL.createObjectURL(file);
+    setProfileImage(previewUrl);
+    setSelectedFile(file);
+  };
+
+  const handleDeleteProfileImage = () => {
+    setProfileImage("");
+  };
+
+  const handleSubmit = async () => {
+    try {
+      await changeUserdata(nickname, profileImage);
+      setDialogMessage("프로필이 성공적으로 변경되었습니다.");
+    } catch (err) {
+      const error = err as AxiosError<{ message?: string }>;
+      const message = error.response?.data?.message;
+      setDialogMessage(message || "프로필 변경에 실패했습니다.");
+    } finally {
+      openDialog(true);
+    }
+  };
+
+  return (
+    <Sheet
+      sheetKey={modalKey}
+      title="프로필 변경"
+      actionType={SheetActionType.Modify}
+      onAction={handleSubmit}
+    >
+      <div className={styles.body}>
+        <section className={styles.profileImageSection}>
+          <div className={styles.profileImage}>
+            <Profile
+              profileImageUrl={profileImage as string}
+              name={userData?.nickname}
+              size={ProfileSize.XLarge}
+            />
+          </div>
+          <div className={styles.profileImageButtons}>
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Small}
+              onClick={(e) => {
+                e.preventDefault();
+                fileInputRef.current?.click();
+              }}
+            >
+              사진 변경
+            </Button>
+            <Button
+              variant={ButtonVariant.Delete}
+              size={ButtonSize.Small}
+              onClick={(e) => {
+                e.preventDefault();
+                handleDeleteProfileImage();
+              }}
+            >
+              사진 삭제
+            </Button>
+            <input
+              className={styles.invisibleFileInput}
+              ref={fileInputRef}
+              type="file"
+              accept="image/*"
+              onChange={onFileChange}
+            />
+          </div>
+        </section>
+        <section className={styles.emailSection}>
+          <p>이메일</p>
+          <Input
+            variant={InputVariant.Default}
+            $size={InputSize.Auto}
+            disabled={true}
+            placeholder={userData?.email || ""}
+          />
+        </section>
+        <section className={styles.nicknameSection}>
+          <p>닉네임</p>
+          <Input
+            variant={InputVariant.Default}
+            $size={InputSize.Auto}
+            value={nickname}
+            onChange={onNicknameChange}
+            placeholder={userData?.nickname || ""}
+          />
+        </section>
+        <section className={styles.passwordSection}>
+          <p>비밀번호</p>
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Small}
+            onClick={(e) => {
+              e.preventDefault();
+              openPasswordChangeModal(true);
+            }}
+          >
+            비밀번호 변경
+          </Button>
+        </section>
+      </div>
+      {isShowPasswordChangeModal && (
+        <PasswordChangeModal modalKey={PASSWORD_CHANGE_MODAL_KEY} />
+      )}
+
+      {isShowDialog && (
+        <Dialog dialogKey={DIALOG_KEY} message={dialogMessage} />
+      )}
+    </Sheet>
+  );
+}

--- a/src/components/account-setting-modal/password-change-modal.module.css
+++ b/src/components/account-setting-modal/password-change-modal.module.css
@@ -1,0 +1,12 @@
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  color: var(--color-gray300);
+}
+
+.inputSection {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}

--- a/src/components/account-setting-modal/password-change-modal.tsx
+++ b/src/components/account-setting-modal/password-change-modal.tsx
@@ -1,0 +1,150 @@
+import Dialog from "@/components/dialog";
+import Input, { InputSize, InputVariant } from "@/components/input/input";
+import Sheet, { SheetActionType } from "@/components/sheet";
+import { changePassword } from "@/features/user/apis/change-password";
+import { useDialog } from "@/hooks/use-dialog";
+import { useModal } from "@/hooks/use-modal";
+import { validatePassword } from "@/utils/validator";
+import { AxiosError } from "axios";
+import { useEffect, useState } from "react";
+import styles from "./password-change-modal.module.css";
+
+interface PasswordChangeModalProps {
+  modalKey: string;
+}
+
+export default function PasswordChangeModal({
+  modalKey,
+}: PasswordChangeModalProps) {
+  const { openModal } = useModal({ key: modalKey });
+  const [password, setPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [newPasswordCheck, setNewPasswordCheck] = useState("");
+  const [newPasswordErrorMessage, setNewPasswordErrorMessage] = useState("");
+  const [newPasswordCheckErrorMessage, setNewPasswordCheckErrorMessage] =
+    useState("");
+  const onClose = () => openModal(false);
+  const [isSubmitButtonDisabled, setIsSubmitButtonDisabled] = useState(true);
+  const [dialogMessage, setDialogMessage] = useState("");
+  const DIALOG_KEY = "DIALOG_CHAGNE_PASSWORD";
+  const { isShowDialog, openDialog } = useDialog({
+    key: DIALOG_KEY,
+  });
+
+  const onNewPasswordBlur = () => {
+    if (!newPassword) {
+      setNewPasswordErrorMessage("");
+      return;
+    }
+
+    if (!validatePassword(newPassword)) {
+      setNewPasswordErrorMessage("8자 이상 입력해주세요");
+      return;
+    }
+
+    if (newPassword !== newPasswordCheck) {
+      setNewPasswordCheckErrorMessage("비밀번호가 일치하지 않습니다");
+    } else {
+      setNewPasswordCheckErrorMessage("");
+    }
+  };
+
+  const onNewPasswordCheckBlur = () => {
+    if (!newPasswordCheck) {
+      setNewPasswordCheckErrorMessage("");
+      return;
+    }
+    if (newPassword === newPasswordCheck) {
+      setNewPasswordCheckErrorMessage("");
+    } else {
+      setNewPasswordCheckErrorMessage("비밀번호가 일치하지 않습니다");
+    }
+  };
+
+  const onNewPasswordFocus = () => {
+    setNewPasswordErrorMessage("");
+  };
+  const onNewPasswordCheckFocus = () => {
+    setNewPasswordCheckErrorMessage("");
+  };
+
+  useEffect(() => {
+    const isFormValid =
+      !!password &&
+      !!newPassword &&
+      validatePassword(newPassword) &&
+      !!newPasswordCheck &&
+      validatePassword(newPasswordCheck) &&
+      newPassword === newPasswordCheck;
+
+    setIsSubmitButtonDisabled(!isFormValid);
+  }, [password, newPassword, newPasswordCheck]);
+
+  const handleSubmit = async () => {
+    try {
+      const response = await changePassword({ password, newPassword });
+      setDialogMessage("비밀번호가 성공적으로 변경되었습니다.");
+    } catch (err) {
+      const error = err as AxiosError<{ message?: string }>;
+      const message = error.response?.data?.message;
+      setDialogMessage(message || "비밀번호 변경에 실패했습니다.");
+    } finally {
+      openDialog(true);
+    }
+  };
+
+  return (
+    <Sheet
+      sheetKey={modalKey}
+      title="비밀번호 변경"
+      actionType={SheetActionType.Modify}
+      canSubmit={!isSubmitButtonDisabled}
+      onAction={handleSubmit}
+    >
+      <div className={styles.body}>
+        <section className={styles.inputSection}>
+          <p>현재 비밀번호</p>
+          <Input
+            variant={InputVariant.Default}
+            $size={InputSize.Auto}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="현재 비밀번호"
+          />
+        </section>
+        <section className={styles.inputSection}>
+          <p>새 비밀번호</p>
+          <Input
+            variant={InputVariant.Password}
+            $size={InputSize.Auto}
+            type="password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+            placeholder="새 비밀번호"
+            onBlur={onNewPasswordBlur}
+            errorMessage={newPasswordErrorMessage}
+            onFocus={onNewPasswordFocus}
+          />
+        </section>
+        <section className={styles.inputSection}>
+          <p>새 비밀번호 확인</p>
+          <Input
+            variant={InputVariant.Password}
+            $size={InputSize.Auto}
+            type="password"
+            value={newPasswordCheck}
+            onChange={(e) => setNewPasswordCheck(e.target.value)}
+            placeholder="새 비밀번호 확인"
+            onBlur={onNewPasswordCheckBlur}
+            errorMessage={newPasswordCheckErrorMessage}
+            onFocus={onNewPasswordCheckFocus}
+          />
+        </section>
+      </div>
+      {isShowDialog && (
+        <Dialog dialogKey={DIALOG_KEY} message={dialogMessage} />
+      )}
+    </Sheet>
+  );
+}

--- a/src/components/navigationBar/navigation-bar.tsx
+++ b/src/components/navigationBar/navigation-bar.tsx
@@ -1,13 +1,13 @@
+import AccountSettingModal from "@/components/account-setting-modal";
+import Modal from "@/components/modal";
+import Typography from "@/components/typography";
 import { CommonSize } from "@/constants/common/common-size";
+import { useModal } from "@/hooks/use-modal";
+import { MemberInfo } from "@/types/member-info";
+import MemberList from "./member-list";
 import styles from "./navigation-bar.module.css";
 import SettingSvg from "./setting-svg";
 import UserPlusSvg from "./user-plus-svg";
-import Link from "next/link";
-import { MemberInfo } from "@/types/member-info";
-import MemberList from "./member-list";
-import Modal from "@/components/modal";
-import { useModal } from "@/hooks/use-modal";
-import Typography from "@/components/typography";
 
 interface NavigationBarProps {
   size?: CommonSize;
@@ -31,9 +31,19 @@ export default function NavigationBar({
   const { isShowModal: isShowModal1, openModal: openModal } = useModal({
     key: MODAL_KEY_1,
   });
-
+  const ACCOUNT_SETTING_MODAL_KEY = "ACCOUNT_SETTING_MODAL";
+  const {
+    isShowModal: isShowAccountSettingModal,
+    openModal: openAccountSettingModal,
+  } = useModal({
+    key: ACCOUNT_SETTING_MODAL_KEY,
+  });
   const handleUserPlus = () => {
     openModal(true);
+  };
+
+  const handleAccountSetting = () => {
+    openAccountSettingModal(true);
   };
 
   let showMembers: MemberInfo[] = [];
@@ -54,10 +64,10 @@ export default function NavigationBar({
         ></MemberList>
       )}
       <div className={styles.rightIcons}>
-        <Link className={styles.iconLink} href={settingLink}>
+        <button onClick={handleAccountSetting} className={styles.iconLink}>
           <SettingSvg className={styles.icon} />
           <span className={iconSpanClasses}>관리</span>
-        </Link>
+        </button>
         <button onClick={() => handleUserPlus()}>
           <UserPlusSvg className={styles.icon} />
           <span className={iconSpanClasses}>공유</span>
@@ -82,6 +92,9 @@ export default function NavigationBar({
             <button onClick={() => openModal(false)}>Close Modal 1</button>
           </div>
         </Modal>
+      )}
+      {isShowAccountSettingModal && (
+        <AccountSettingModal modalKey={ACCOUNT_SETTING_MODAL_KEY} />
       )}
     </div>
   );

--- a/src/features/user/apis/change-password.ts
+++ b/src/features/user/apis/change-password.ts
@@ -1,0 +1,17 @@
+import axiosInstance from "@/services/axios-instance";
+
+interface ChangePasswordRequest {
+  password: string;
+  newPassword: string;
+}
+
+interface ChangePasswordResponse {
+  message: string;
+}
+
+export async function changePassword(
+  body: ChangePasswordRequest
+): Promise<ChangePasswordResponse> {
+  const response = await axiosInstance.put("/auth/password", body);
+  return response.data;
+}

--- a/src/features/user/apis/change-userdata.ts
+++ b/src/features/user/apis/change-userdata.ts
@@ -1,0 +1,26 @@
+import axiosInstance from "@/services/axios-instance";
+
+interface ChangePasswordRequest {
+  nickname: string;
+  profileImageUrl: string;
+}
+
+interface ChangePasswordResponse {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function changeUserdata(
+  nickname: string,
+  profileImage: string
+): Promise<ChangePasswordResponse> {
+  const response = await axiosInstance.put("/users/me", {
+    nickname,
+    profileImageUrl: profileImage,
+  });
+  return response.data;
+}

--- a/src/features/user/apis/get-me.ts
+++ b/src/features/user/apis/get-me.ts
@@ -1,0 +1,15 @@
+import axiosInstance from "@/services/axios-instance";
+
+export interface GetMeResponse {
+  id: number;
+  email: string;
+  nickname: string;
+  profileImageUrl: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export async function getMe(): Promise<GetMeResponse> {
+  const reponse = await axiosInstance.get("/users/me");
+  return reponse.data;
+}

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -39,7 +39,7 @@ export default async function handler(
       res.setHeader("Set-Cookie", cookie);
       return res
         .status(201)
-        .json({ accessToken: data.accessToken, user: data });
+        .json({ accessToken: data.accessToken, user: data.user });
     }
 
     return res.status(401).json({ message: "Login failed" });


### PR DESCRIPTION
## 📝 작업 내용

- 계정관리 모달창 구현
- 비밀번호, 닉네임 변경 구현

## 📷 스크린샷 (선택)

<img width="745" height="805" alt="1" src="https://github.com/user-attachments/assets/25a246dc-3864-4622-be3e-6fef25516c0b" />
<img width="750" height="633" alt="2" src="https://github.com/user-attachments/assets/5ccbf37b-93b0-4324-a098-65d75eadffde" />


## 🧐 해결해야 하는 문제 (선택)

- 반응형 추가
- 프로필 변경 기능

## 💬 리뷰어에게 남길 말 (선택)

프로필 변경이 스웨거로 테스트해도 잘 안되는거 같아서 이게 진짜 문제가있는건지
제가 잘못하고있는건지 확인을 해봐야할거 같습니다.
다음은 회원가입 -> 로그인 에서 자동완성 문제에 대해 작업할 예정입니다.

