### PR TITLE
[#97] CardDetailModal, CardEditSheet 개발 / Column 생성 및 수정에 `ColumnEditSheet` 연동

### DIFF
--- a/src/components/dashboard/column/column.tsx
+++ b/src/components/dashboard/column/column.tsx
@@ -13,6 +13,7 @@ export enum ColumnActionType {
 interface ColumnProps {
   columnTitle: string;
   cards: CardData[];
+  isLoadingCards: boolean;
   onCardClick: (card: CardData) => void;
   onClick?: (type: ColumnActionType) => void;
 }
@@ -20,6 +21,7 @@ interface ColumnProps {
 export default function Column({
   columnTitle,
   cards = [],
+  isLoadingCards,
   onCardClick,
   onClick,
 }: ColumnProps) {
@@ -39,11 +41,15 @@ export default function Column({
           </button>
         </div>
       </div>
-      {cards.map((card) => (
-        <div key={card.id}>
-          <Card card={card} onClick={() => onCardClick(card)} />
-        </div>
-      ))}
+      {isLoadingCards ? (
+        <div>카드 로딩중...</div>
+      ) : (
+        cards.map((card) => (
+          <div key={card.id}>
+            <Card card={card} onClick={() => onCardClick(card)} />
+          </div>
+        ))
+      )}
     </section>
   );
 }

--- a/src/components/dashboard/column/column.tsx
+++ b/src/components/dashboard/column/column.tsx
@@ -1,8 +1,8 @@
 import Card from "@/components/dashboard/card/card";
-import styles from "./column.module.css";
-import { Card as CardData } from "@/types/card";
 import SettingSvg from "@/components/navigationBar/setting-svg";
 import Typography from "@/components/typography";
+import { Card as CardData } from "@/types/card";
+import styles from "./column.module.css";
 import PlusSvg from "./plus-svg";
 
 export enum ColumnActionType {

--- a/src/components/dashboard/column/mock/index.ts
+++ b/src/components/dashboard/column/mock/index.ts
@@ -1,0 +1,10 @@
+import { Column } from "@/types";
+import columnsMock from "./column.json";
+
+export async function getColumn({
+  dashboardId,
+}: {
+  dashboardId: number;
+}): Promise<Column[]> {
+  return columnsMock.data;
+}

--- a/src/components/input/textarea.tsx
+++ b/src/components/input/textarea.tsx
@@ -22,7 +22,7 @@ export default function Textarea({
       {...props}
       className={`${styles.textarea}
                   ${styles[size]} 
-                  ${Typography.lgMedium} 
+                  ${Typography.lgMedium160} 
                   ${className ?? ""} `}
     />
   );

--- a/src/components/sheet/index.tsx
+++ b/src/components/sheet/index.tsx
@@ -12,7 +12,7 @@ export enum SheetActionType {
   Cancel = "취소",
   Create = "생성",
   Done = "완료",
-  Modify = "변경",
+  Update = "변경",
 }
 
 interface SheetActionProps {
@@ -29,7 +29,7 @@ function SheetAction({ type, onClick, disabled }: SheetActionProps) {
       [SheetActionType.Cancel]: ButtonVariant.Secondary,
       [SheetActionType.Create]: ButtonVariant.Primary,
       [SheetActionType.Done]: ButtonVariant.Primary,
-      [SheetActionType.Modify]: ButtonVariant.Primary,
+      [SheetActionType.Update]: ButtonVariant.Primary,
     }[type];
   }, [type]);
 

--- a/src/components/sheet/sheet-section-group.module.css
+++ b/src/components/sheet/sheet-section-group.module.css
@@ -1,6 +1,6 @@
 .sheetSectionGroup {
   display: flex;
-  gap: 8px;
+  gap: 20px;
 }
 
 .sheetSectionGroupItem {

--- a/src/features/card/apis/index.ts
+++ b/src/features/card/apis/index.ts
@@ -2,33 +2,71 @@ import axiosInstance from "@/services/axios-instance";
 import { withThrowingAxiosError } from "@/services/with-throwing-axios-error";
 import { Card } from "@/types/card";
 
-export async function updateCard({
-  userId,
-  card,
-}: {
-  userId: number;
-  card: Partial<Card>;
-}): Promise<Card> {
-  return withThrowingAxiosError<Card>(async () => {
-    const response = await axiosInstance.put(`/cards/${card.id}`, {
-      columnId: card.columnId,
-      assigneeUserId: userId,
-      title: card.title,
-      description: card.description,
-      dueDate: card.dueDate,
-      tags: card.tags,
-      imageUrl: card.imageUrl,
-    });
+export interface CardParams {
+  columnId?: number;
+  assigneeUserId?: number;
+  title: string;
+  description: string;
+  // dueDate: string;
+  tags: string[];
+  imageUrl: string;
+}
 
+export interface CreateCardParams extends CardParams {
+  dashboardId: number;
+}
+
+/**
+ * 임시 더미 날짜 생성 함수
+ * YYYY-MM-DD HH:mm 형식의 문자열 사용
+ * Card 생성/수정 시 due date를 입력하는 input을 개발하면 삭제해야 함
+ */
+const dummyDate = () => {
+  const numberWithZeroPadding = (num: number) => String(num).padStart(2, "0");
+
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = numberWithZeroPadding(date.getMonth() + 1);
+  const day = numberWithZeroPadding(date.getDate());
+  const hours = numberWithZeroPadding(date.getHours());
+  const minutes = numberWithZeroPadding(date.getMinutes());
+  return `${year}-${month}-${day} ${hours}:${minutes}`;
+};
+
+export async function getCard({ cardId }: { cardId: number }) {
+  return withThrowingAxiosError<Card>(async () => {
+    const response = await axiosInstance.get<Card>(`/cards/${cardId}`);
     return response.data;
   });
 }
 
-export async function deleteCard({
+export async function createCard({ params }: { params: CreateCardParams }) {
+  return withThrowingAxiosError<Card>(async () => {
+    const response = await axiosInstance.post<Card>(`/cards`, {
+      ...params,
+      dueDate: dummyDate(),
+    });
+    return response.data;
+  });
+}
+
+export async function updateCard({
   cardId,
+  params,
 }: {
   cardId: number;
-}): Promise<void> {
+  params: CardParams;
+}) {
+  return withThrowingAxiosError<Card>(async () => {
+    const response = await axiosInstance.put<Card>(`/cards/${cardId}`, {
+      ...params,
+      dueDate: dummyDate(),
+    });
+    return response.data;
+  });
+}
+
+export async function deleteCard({ cardId }: { cardId: number }) {
   return withThrowingAxiosError<void>(async () => {
     const response = await axiosInstance.delete(`/cards/${cardId}`);
     return response.data;

--- a/src/features/card/components/card-detail-modal.module.css
+++ b/src/features/card/components/card-detail-modal.module.css
@@ -4,7 +4,7 @@
 }
 
 .main {
-  max-width: 644px;
+  width: 644px;
   height: 880px;
   padding-right: 14px;
 }
@@ -81,6 +81,7 @@
 }
 
 .comments {
+  width: 100%;
   padding-top: 30px;
   border-top: 1px solid var(--color-gray800);
   display: flex;

--- a/src/features/card/components/card-detail-modal.tsx
+++ b/src/features/card/components/card-detail-modal.tsx
@@ -250,6 +250,7 @@ interface Props {
   columns: Column[];
   members: MemberInfo[];
   onDelete: () => void;
+  onUpdate: () => void;
 }
 
 export default function CardDetailModal({
@@ -259,6 +260,7 @@ export default function CardDetailModal({
   columns,
   members,
   onDelete,
+  onUpdate,
 }: Props) {
   const [card, setCard] = useState<Card>(initialCard);
 
@@ -309,6 +311,7 @@ export default function CardDetailModal({
   const handleCardUpdate = async (params: CardParams) => {
     const newCard = await updateCard({ cardId: card.id, params });
     setCard(newCard);
+    onUpdate();
     openSheet(false);
   };
 

--- a/src/features/card/components/card-detail-modal.tsx
+++ b/src/features/card/components/card-detail-modal.tsx
@@ -11,14 +11,14 @@ import { ProfileSize } from "@/components/profile/profile-size";
 import Typography from "@/components/typography";
 import { CardParams, deleteCard, updateCard } from "@/features/card/apis";
 import { Direction, Menu, MenuItem } from "@/features/card/components/menu";
-import { getComments } from "@/features/comment/apis/mock";
+import { createComment, getComments } from "@/features/comment/apis";
 import { CommentInput, CommentList } from "@/features/comment/components";
 import { useAlert } from "@/hooks/use-alert";
 import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
 import { useResponsive } from "@/hooks/use-responsive";
 import { useSheet } from "@/hooks/use-sheet";
-import type { Card, Column, Comment, MemberInfo } from "@/types";
+import type { Card, Column, Comment, Dashboard, MemberInfo } from "@/types";
 import { classnames } from "@/utils/classnames";
 import { formatDueDate } from "@/utils/date-formatter";
 import Image from "next/image";
@@ -137,13 +137,13 @@ function Sidebar({
 
 interface MainProps extends ActionsProps {
   card: Card;
-  dashboardTitle: string;
+  dashboard: Dashboard;
   columnTitle: string;
 }
 
 function Main({
   card,
-  dashboardTitle,
+  dashboard,
   columnTitle,
   onEdit,
   onDelete,
@@ -152,22 +152,39 @@ function Main({
   const [comments, setComments] = useState<Comment[]>([]);
   const { isDesktop } = useResponsive();
 
+  const FAIL_DIALOG_KEY = "fail-dialog-from-card-detail-modal";
+  const { isShowDialog, openDialog } = useDialog({ key: FAIL_DIALOG_KEY });
+  const [failMessage, setFailMessage] = useState("");
+
   useEffect(() => {
     async function loadComments() {
       try {
-        const data = await getComments();
-        setComments(data);
-      } catch (error) {
-        // TODO: Error handling
-        console.error(error);
+        const comments = await getComments({ cardId: card.id });
+        setComments(comments);
+      } catch {
+        setComments([]);
       }
     }
     loadComments();
-  }, []);
+  }, [card]);
 
-  const handleCommentSubmit = (value: string) => {
-    // TODO: Add comment
-    console.log("Submit comment:", value);
+  const handleCommentSubmit = async (value: string) => {
+    try {
+      const newComment = await createComment({
+        params: {
+          cardId: card.id,
+          columnId: card.columnId,
+          dashboardId: dashboard.id,
+          content: value,
+        },
+      });
+      setComments((prevComments) => [...prevComments, newComment]);
+    } catch (error) {
+      if (error instanceof Error) {
+        setFailMessage(error.message);
+        openDialog(true);
+      }
+    }
   };
 
   return (
@@ -204,7 +221,7 @@ function Main({
         {isDesktop || (
           <div className={styles.info}>
             <ProjectInfo
-              dashboardTitle={dashboardTitle}
+              dashboardTitle={dashboard.title}
               columnTitle={columnTitle}
             />
             <AssigneeInfo name={card.assignee.nickname} />
@@ -219,6 +236,9 @@ function Main({
           <CommentList comments={comments} />
         </div>
       </div>
+      {isShowDialog && (
+        <Dialog dialogKey={FAIL_DIALOG_KEY} message={failMessage} />
+      )}
     </div>
   );
 }
@@ -226,7 +246,7 @@ function Main({
 interface Props {
   modalKey: string;
   card: Card;
-  dashboardTitle: string;
+  dashboard: Dashboard;
   columns: Column[];
   members: MemberInfo[];
   onDelete: () => void;
@@ -235,7 +255,7 @@ interface Props {
 export default function CardDetailModal({
   modalKey,
   card: initialCard,
-  dashboardTitle,
+  dashboard,
   columns,
   members,
   onDelete,
@@ -297,7 +317,7 @@ export default function CardDetailModal({
       <div className={styles.cardDetailModal}>
         <Main
           card={card}
-          dashboardTitle={dashboardTitle}
+          dashboard={dashboard}
           columnTitle={columnTitle}
           onEdit={handleEdit}
           onDelete={handleDelete}
@@ -305,7 +325,7 @@ export default function CardDetailModal({
         />
         {isDesktop && (
           <Sidebar
-            dashboardTitle={dashboardTitle}
+            dashboardTitle={dashboard.title}
             columnTitle={columnTitle}
             assignee={card.assignee.nickname}
             dueDate={card.dueDate}

--- a/src/features/card/components/card-detail-modal.tsx
+++ b/src/features/card/components/card-detail-modal.tsx
@@ -1,4 +1,3 @@
-import SampleImage from "@/assets/images/dashboard-gui.png";
 import Alert, { AlertActionType } from "@/components/alert";
 import IconButton from "@/components/button/icon-button";
 import Badge from "@/components/chips/badge/badge";
@@ -10,7 +9,7 @@ import Modal from "@/components/modal";
 import Profile from "@/components/profile/profile";
 import { ProfileSize } from "@/components/profile/profile-size";
 import Typography from "@/components/typography";
-import { deleteCard } from "@/features/card/apis";
+import { CardParams, deleteCard, updateCard } from "@/features/card/apis";
 import { Direction, Menu, MenuItem } from "@/features/card/components/menu";
 import { getComments } from "@/features/comment/apis/mock";
 import { CommentInput, CommentList } from "@/features/comment/components";
@@ -18,13 +17,14 @@ import { useAlert } from "@/hooks/use-alert";
 import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
 import { useResponsive } from "@/hooks/use-responsive";
-import { Card } from "@/types/card";
-import { Comment } from "@/types/comment";
+import { useSheet } from "@/hooks/use-sheet";
+import type { Card, Column, Comment, MemberInfo } from "@/types";
 import { classnames } from "@/utils/classnames";
 import { formatDueDate } from "@/utils/date-formatter";
 import Image from "next/image";
 import { ReactNode, useEffect, useState } from "react";
 import styles from "./card-detail-modal.module.css";
+import CardEditSheet from "./card-edit-sheet";
 
 interface ActionsProps {
   onEdit: () => void;
@@ -185,17 +185,21 @@ function Main({
               <Actions onEdit={onEdit} onDelete={onDelete} onClose={onClose} />
             )}
           </h2>
-          <div className={styles.tagsList}>
-            {card.tags.map((tag) => (
-              <Badge key={tag} title={tag} />
-            ))}
-          </div>
+          {card.tags.length > 0 && (
+            <div className={styles.tagsList}>
+              {card.tags.map((tag) => (
+                <Badge key={tag} title={tag} />
+              ))}
+            </div>
+          )}
         </header>
         <article className={styles.content}>
           <p className={Typography.lgMedium160}>{card.description}</p>
-          <div className={styles.image}>
-            <Image src={SampleImage} alt="카드에 등록된 이미지" fill />
-          </div>
+          {card.imageUrl && (
+            <div className={styles.image}>
+              <Image src={card.imageUrl} alt="카드에 등록된 이미지" fill />
+            </div>
+          )}
         </article>
         {isDesktop || (
           <div className={styles.info}>
@@ -223,15 +227,21 @@ interface Props {
   modalKey: string;
   card: Card;
   dashboardTitle: string;
-  columnTitle: string;
+  columns: Column[];
+  members: MemberInfo[];
+  onDelete: () => void;
 }
 
 export default function CardDetailModal({
   modalKey,
-  card,
+  card: initialCard,
   dashboardTitle,
-  columnTitle,
+  columns,
+  members,
+  onDelete,
 }: Props) {
+  const [card, setCard] = useState<Card>(initialCard);
+
   const { openModal } = useModal({ key: modalKey });
   const { isDesktop, isMobile } = useResponsive();
 
@@ -242,8 +252,16 @@ export default function CardDetailModal({
   const { isShowDialog, openDialog } = useDialog({ key: dialogKey });
   const [dialogMessage, setDialogMessage] = useState("");
 
+  const sheetKey = "card-edit-sheet-from-card-detail-modal";
+  const { isShowSheet, openSheet } = useSheet({
+    key: sheetKey,
+  });
+
+  const columnTitle =
+    columns?.find((column) => card.columnId === column.id)?.title ?? "";
+
   const handleEdit = () => {
-    // TODO: Show CardEditSheet
+    openSheet(true);
   };
 
   const handleDelete = async () => {
@@ -254,10 +272,10 @@ export default function CardDetailModal({
 
     try {
       await deleteCard({ cardId: card.id });
+      onDelete();
       openModal(false);
     } catch (error) {
       if (error instanceof Error) {
-        console.log(error);
         setDialogMessage(error.message);
         openDialog(true);
       }
@@ -266,6 +284,12 @@ export default function CardDetailModal({
 
   const handleClose = () => {
     openModal(false);
+  };
+
+  const handleCardUpdate = async (params: CardParams) => {
+    const newCard = await updateCard({ cardId: card.id, params });
+    setCard(newCard);
+    openSheet(false);
   };
 
   return (
@@ -301,6 +325,15 @@ export default function CardDetailModal({
         />
       )}
       {isShowDialog && <Dialog dialogKey={dialogKey} message={dialogMessage} />}
+      {isShowSheet && (
+        <CardEditSheet
+          sheetKey={sheetKey}
+          card={card}
+          columns={columns}
+          members={members}
+          onUpdate={handleCardUpdate}
+        />
+      )}
     </Modal>
   );
 }

--- a/src/features/card/components/card-edit-sheet.tsx
+++ b/src/features/card/components/card-edit-sheet.tsx
@@ -120,17 +120,12 @@ export default function CardEditSheet({
       imageUrl,
     };
 
-    console.log(members);
-    console.log(assignee);
-
     switch (sheetActionType) {
       case SheetActionType.Create:
         onCreate?.(editValues);
-        console.log("CardEditSheet - handleAction - Create", editValues);
         break;
       case SheetActionType.Update:
         onUpdate?.(editValues);
-        console.log("CardEditSheet - handleAction - Update", editValues);
         break;
     }
   };

--- a/src/features/card/components/card-edit-sheet.tsx
+++ b/src/features/card/components/card-edit-sheet.tsx
@@ -1,0 +1,205 @@
+import Input, { InputSize } from "@/components/input/input";
+import Textarea from "@/components/input/textarea";
+import Profile from "@/components/profile/profile";
+import Sheet, { SheetActionType } from "@/components/sheet";
+import SheetSection from "@/components/sheet/sheet-section";
+import SheetSectionGroup from "@/components/sheet/sheet-section-group";
+import Typography from "@/components/typography";
+import Dropdown from "@/features/card/components/dropdown";
+import { uploadCardImage } from "@/features/column/apis";
+import type { Card, CardAssignee, Column, MemberInfo } from "@/types";
+import { ChangeEvent, useState } from "react";
+import { CardParams } from "../apis";
+import ImageInput from "./image-input";
+import TagInput from "./tag-input";
+
+interface Props {
+  sheetKey: string;
+  card?: Card;
+  columns: Column[];
+  members: MemberInfo[];
+  onCreate?: (params: CardParams) => void;
+  onUpdate?: (params: CardParams) => void;
+}
+
+export default function CardEditSheet({
+  sheetKey,
+  card,
+  columns,
+  members,
+  onCreate,
+  onUpdate,
+}: Props) {
+  const [title, setTitle] = useState<string>(card?.title ?? "");
+  const [description, setDescription] = useState<string>(
+    card?.description ?? ""
+  );
+  const [column, setColumn] = useState<Column | null>(() => {
+    const index = columns.findIndex((column) => column.id === card?.columnId);
+    return index !== -1 ? columns[index] : null;
+  });
+  const [assignee, setAssignee] = useState<CardAssignee | undefined>(
+    card?.assignee
+  );
+  const [tags, setTags] = useState<string[]>(card?.tags ?? []);
+  const [image, setImage] = useState<File>();
+
+  const sheetTitle = card ? "할 일 수정" : "할 일 생성";
+  const sheetActionType = card
+    ? SheetActionType.Update
+    : SheetActionType.Create;
+
+  const hasRequiredField =
+    title.trim() !== "" &&
+    description.trim() !== "" &&
+    column !== null &&
+    assignee !== undefined &&
+    (card ? true : image !== undefined);
+
+  const hasChangedValue =
+    title !== card?.title ||
+    description !== card?.description ||
+    column?.id !== card?.columnId ||
+    assignee?.id !== card?.assignee?.id ||
+    JSON.stringify(tags) !== JSON.stringify(card?.tags) ||
+    image !== null;
+
+  let canSubmit;
+  switch (sheetActionType) {
+    case SheetActionType.Create:
+      canSubmit = hasRequiredField;
+      break;
+    case SheetActionType.Update:
+      canSubmit = hasRequiredField && hasChangedValue;
+      break;
+  }
+
+  const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setTitle(event.target.value);
+  };
+
+  const handleDescriptionChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    setDescription(event.target.value);
+  };
+
+  const handleColumnSelect = (value: string) => {
+    const selectedIndex = columns.findIndex((column) => column.title === value);
+    setColumn(columns[selectedIndex]);
+  };
+
+  const handleAssigneeSelect = (value: string) => {
+    const selectedMember = members.find((member) => member.nickname === value);
+    if (selectedMember) {
+      setAssignee({
+        profileImageUrl: selectedMember.profileImageUrl,
+        nickname: selectedMember.nickname,
+        id: selectedMember.userId,
+      });
+    }
+  };
+
+  const handleTagsChange = (tags: string[]) => {
+    setTags(tags);
+  };
+
+  const handleAction = async () => {
+    let imageUrl = card?.imageUrl ?? "";
+    if (image) {
+      imageUrl = await uploadCardImage({
+        columnId: column!.id,
+        imageFile: image,
+      });
+    }
+
+    const editValues: CardParams = {
+      columnId: column?.id,
+      assigneeUserId: assignee?.id,
+      title,
+      description,
+      tags,
+      imageUrl,
+    };
+
+    console.log(members);
+    console.log(assignee);
+
+    switch (sheetActionType) {
+      case SheetActionType.Create:
+        onCreate?.(editValues);
+        console.log("CardEditSheet - handleAction - Create", editValues);
+        break;
+      case SheetActionType.Update:
+        onUpdate?.(editValues);
+        console.log("CardEditSheet - handleAction - Update", editValues);
+        break;
+    }
+  };
+
+  return (
+    <Sheet
+      sheetKey={sheetKey}
+      title={sheetTitle}
+      actionType={sheetActionType}
+      onAction={handleAction}
+      canSubmit={canSubmit}
+    >
+      <SheetSection title="제목" required>
+        <Input
+          value={title}
+          placeholder="제목을 입력해주세요"
+          $size={InputSize.Auto}
+          onChange={handleTitleChange}
+        />
+      </SheetSection>
+      <SheetSection title="설명" required>
+        <Textarea
+          value={description}
+          placeholder="설명을 입력해주세요"
+          onChange={handleDescriptionChange}
+        />
+      </SheetSection>
+      <SheetSectionGroup zIndex={2}>
+        <SheetSection title="칼럼" required>
+          <Dropdown
+            value={column && column.title}
+            placeholder="칼럼 선택"
+            options={columns.map((column) => column.title)}
+            onSelect={handleColumnSelect}
+          />
+        </SheetSection>
+        <SheetSection title="담당자" required>
+          <Dropdown
+            value={
+              assignee && (
+                <Profile
+                  showFullName
+                  name={assignee.nickname}
+                  fullNameSize={Typography.lgMedium}
+                />
+              )
+            }
+            placeholder="담당자 선택"
+            options={members.map((member) => ({
+              element: (
+                <Profile
+                  key={`member-${member.id}`}
+                  showFullName
+                  name={member.nickname}
+                  fullNameSize={Typography.lgMedium}
+                />
+              ),
+              value: member.nickname,
+            }))}
+            onSelect={handleAssigneeSelect}
+          />
+        </SheetSection>
+      </SheetSectionGroup>
+      <SheetSection title="태그" zIndex={1}>
+        <TagInput tags={tags} onChange={handleTagsChange} />
+      </SheetSection>
+      <SheetSection title="이미지" required>
+        <ImageInput imageUrl={card?.imageUrl} onChange={setImage} />
+      </SheetSection>
+    </Sheet>
+  );
+}

--- a/src/features/column/apis/index.ts
+++ b/src/features/column/apis/index.ts
@@ -1,0 +1,27 @@
+import axiosInstance from "@/services/axios-instance";
+import { withThrowingAxiosError } from "@/services/with-throwing-axios-error";
+
+export async function uploadCardImage({
+  columnId,
+  imageFile,
+}: {
+  columnId: number;
+  imageFile: File;
+}): Promise<string> {
+  return withThrowingAxiosError<string>(async () => {
+    const formData = new FormData();
+    formData.append("image", imageFile);
+
+    const response = await axiosInstance.post<{ imageUrl: string }>(
+      `/columns/${columnId}/card-image`,
+      formData,
+      { headers: { "Content-Type": "multipart/form-data" } }
+    );
+
+    if (response.status !== 201) {
+      return "";
+    }
+
+    return response.data.imageUrl;
+  });
+}

--- a/src/features/column/apis/index.ts
+++ b/src/features/column/apis/index.ts
@@ -1,5 +1,6 @@
 import axiosInstance from "@/services/axios-instance";
 import { withThrowingAxiosError } from "@/services/with-throwing-axios-error";
+import { Column } from "@/types";
 
 export async function createColumn({
   dashboardId,
@@ -9,7 +10,7 @@ export async function createColumn({
   title: string;
 }) {
   return withThrowingAxiosError(async () => {
-    const response = await axiosInstance.post(`/columns`, {
+    const response = await axiosInstance.post<Column>(`/columns`, {
       title,
       dashboardId,
     });
@@ -25,7 +26,9 @@ export async function updateColumn({
   title: string;
 }) {
   return withThrowingAxiosError(async () => {
-    const response = await axiosInstance.put(`/columns/${columnId}`, { title });
+    const response = await axiosInstance.put<Column>(`/columns/${columnId}`, {
+      title,
+    });
     return response.data;
   });
 }

--- a/src/features/column/apis/index.ts
+++ b/src/features/column/apis/index.ts
@@ -1,6 +1,35 @@
 import axiosInstance from "@/services/axios-instance";
 import { withThrowingAxiosError } from "@/services/with-throwing-axios-error";
 
+export async function createColumn({
+  dashboardId,
+  title,
+}: {
+  dashboardId: number;
+  title: string;
+}) {
+  return withThrowingAxiosError(async () => {
+    const response = await axiosInstance.post(`/columns`, {
+      title,
+      dashboardId,
+    });
+    return response.data;
+  });
+}
+
+export async function updateColumn({
+  columnId,
+  title,
+}: {
+  columnId: number;
+  title: string;
+}) {
+  return withThrowingAxiosError(async () => {
+    const response = await axiosInstance.put(`/columns/${columnId}`, { title });
+    return response.data;
+  });
+}
+
 export async function uploadCardImage({
   columnId,
   imageFile,

--- a/src/features/column/components/column-edit-sheet.tsx
+++ b/src/features/column/components/column-edit-sheet.tsx
@@ -23,7 +23,7 @@ export default function ColumnEditSheet({
   const [errorMessage, setErrorMessage] = useState<string | undefined>();
 
   const sheetTitle = column ? "칼럼 관리" : "새 칼럼 생성";
-  const actionType = column ? SheetActionType.Modify : SheetActionType.Create;
+  const actionType = column ? SheetActionType.Update : SheetActionType.Create;
   const canSubmit = title.length > 0 && column?.title !== title;
 
   const handleTitleChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/features/comment/apis/index.ts
+++ b/src/features/comment/apis/index.ts
@@ -1,0 +1,33 @@
+import axiosInstance from "@/services/axios-instance";
+import { withThrowingAxiosError } from "@/services/with-throwing-axios-error";
+import { Comment } from "@/types";
+
+interface GetCommentsResponse {
+  cursorId: number;
+  comments: Comment[];
+}
+
+export async function getComments({ cardId }: { cardId: number }) {
+  return withThrowingAxiosError<Comment[]>(async () => {
+    const response = await axiosInstance.get<GetCommentsResponse>(`/comments`, {
+      params: { cardId },
+    });
+    return response.data.comments;
+  });
+}
+
+export async function createComment({
+  params,
+}: {
+  params: {
+    cardId: number;
+    columnId: number;
+    dashboardId: number;
+    content: string;
+  };
+}) {
+  return withThrowingAxiosError<Comment>(async () => {
+    const response = await axiosInstance.post<Comment>(`/comments`, params);
+    return response.data;
+  });
+}

--- a/src/features/member/apis/mock/index.ts
+++ b/src/features/member/apis/mock/index.ts
@@ -1,0 +1,14 @@
+/** TODO
+ * 1. Members mocking
+ * 2. Columns와 members를 CardEditSheet에 props로 전달
+ * 3. Dropdown에서 columns와 members 선택하는 기능 테스트
+ * 4. Members는 profile과 name이 합쳐진 component를 options로 사용
+ * 5. ...
+ */
+
+import { MemberInfo } from "@/types";
+import membersMock from "./members.json";
+
+export async function getMembers(): Promise<MemberInfo[]> {
+  return membersMock.members;
+}

--- a/src/features/member/apis/mock/members.json
+++ b/src/features/member/apis/mock/members.json
@@ -1,0 +1,105 @@
+{
+  "members": [
+    {
+      "id": 1,
+      "userId": 101,
+      "email": "shin.teamlead@company.com",
+      "nickname": "신팀장",
+      "profileImageUrl": "https://api.example.com/avatars/user-987.jpg",
+      "createdAt": "2025-09-15T09:00:00.000Z",
+      "updatedAt": "2025-09-15T09:00:00.000Z",
+      "isOwner": true
+    },
+    {
+      "id": 2,
+      "userId": 102,
+      "email": "kim.dev@company.com",
+      "nickname": "김개발",
+      "profileImageUrl": "https://api.example.com/avatars/user-123.jpg",
+      "createdAt": "2025-09-15T09:15:30.123Z",
+      "updatedAt": "2025-10-14T11:20:45.678Z",
+      "isOwner": false
+    },
+    {
+      "id": 3,
+      "userId": 103,
+      "email": "lee.review@company.com",
+      "nickname": "이리뷰",
+      "profileImageUrl": "https://api.example.com/avatars/user-456.jpg",
+      "createdAt": "2025-09-16T10:30:45.234Z",
+      "updatedAt": "2025-09-16T10:30:45.234Z",
+      "isOwner": false
+    },
+    {
+      "id": 4,
+      "userId": 104,
+      "email": "park.data@company.com",
+      "nickname": "박데이터",
+      "profileImageUrl": "https://api.example.com/avatars/user-789.jpg",
+      "createdAt": "2025-09-17T14:20:15.456Z",
+      "updatedAt": "2025-10-12T08:15:30.234Z",
+      "isOwner": false
+    },
+    {
+      "id": 5,
+      "userId": 105,
+      "email": "choi.security@company.com",
+      "nickname": "최보안",
+      "profileImageUrl": "https://api.example.com/avatars/user-321.jpg",
+      "createdAt": "2025-09-18T08:45:22.567Z",
+      "updatedAt": "2025-09-18T08:45:22.567Z",
+      "isOwner": false
+    },
+    {
+      "id": 6,
+      "userId": 106,
+      "email": "jung.frontend@company.com",
+      "nickname": "정프론트",
+      "profileImageUrl": "https://api.example.com/avatars/user-654.jpg",
+      "createdAt": "2025-09-20T11:12:33.678Z",
+      "updatedAt": "2025-09-20T11:12:33.678Z",
+      "isOwner": false
+    },
+    {
+      "id": 7,
+      "userId": 107,
+      "email": "han.design@company.com",
+      "nickname": "한디자인",
+      "profileImageUrl": "https://api.example.com/avatars/user-432.jpg",
+      "createdAt": "2025-09-22T15:30:44.789Z",
+      "updatedAt": "2025-10-15T16:40:22.345Z",
+      "isOwner": false
+    },
+    {
+      "id": 8,
+      "userId": 108,
+      "email": "oh.devops@company.com",
+      "nickname": "오데브옵스",
+      "profileImageUrl": "https://api.example.com/avatars/user-876.jpg",
+      "createdAt": "2025-09-25T13:25:55.890Z",
+      "updatedAt": "2025-09-25T13:25:55.890Z",
+      "isOwner": false
+    },
+    {
+      "id": 9,
+      "userId": 109,
+      "email": "kang.qa@company.com",
+      "nickname": "강QA",
+      "profileImageUrl": "https://api.example.com/avatars/user-543.jpg",
+      "createdAt": "2025-10-01T09:50:11.234Z",
+      "updatedAt": "2025-10-01T09:50:11.234Z",
+      "isOwner": false
+    },
+    {
+      "id": 10,
+      "userId": 110,
+      "email": "lim.backend@company.com",
+      "nickname": "임백엔드",
+      "profileImageUrl": "https://api.example.com/avatars/user-765.jpg",
+      "createdAt": "2025-10-05T16:38:26.345Z",
+      "updatedAt": "2025-10-16T09:15:44.123Z",
+      "isOwner": false
+    }
+  ],
+  "totalCount": 10
+}

--- a/src/hooks/use-cards.tsx
+++ b/src/hooks/use-cards.tsx
@@ -1,27 +1,25 @@
 import { getCards } from "@/components/dashboard/card/api/cards";
 import { useAuth } from "@/features/auth/components/auth-provider";
 import { Card } from "@/types/card";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export function useCards(columnIds: number[]) {
   const [cards, setCards] = useState<Record<number, Card[]> | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingCards, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const { isLoadingToken } = useAuth();
 
-  useEffect(() => {
-    if (isLoadingToken) return;
-
-    if (columnIds.length === 0) {
-      setCards(null);
-      return;
-    }
-
-    const getCardData = async () => {
-      setIsLoading(true);
+  const getCardData = useCallback(
+    async ({ loading }: { loading: boolean } = { loading: true }) => {
+      setIsLoading(loading);
       setError(null);
 
       try {
+        if (columnIds.length === 0) {
+          setCards(null);
+          return;
+        }
+
         const cardsPromises = columnIds.map((columnId) =>
           getCards({ columnId })
         );
@@ -44,10 +42,14 @@ export function useCards(columnIds: number[]) {
       } finally {
         setIsLoading(false);
       }
-    };
+    },
+    [columnIds]
+  );
 
+  useEffect(() => {
+    if (isLoadingToken) return;
     getCardData();
-  }, [columnIds, isLoadingToken]);
+  }, [isLoadingToken, getCardData]);
 
-  return { cards, isLoading, error };
+  return { cards, isLoadingCards, error, reloadCards: getCardData };
 }

--- a/src/hooks/use-column.tsx
+++ b/src/hooks/use-column.tsx
@@ -1,27 +1,25 @@
 import { getColumn } from "@/components/dashboard/column/api/column";
 import { useAuth } from "@/features/auth/components/auth-provider";
 import { Column } from "@/types/column";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export function useColumn(dashboardId: number | null) {
   const [columns, setColumns] = useState<Column[] | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingColumns, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
   const { isLoadingToken } = useAuth();
 
-  useEffect(() => {
-    if (isLoadingToken) return;
-
-    if (!dashboardId) {
-      setColumns(null);
-      return;
-    }
-
-    const loadColumns = async () => {
-      setIsLoading(true);
+  const loadColumns = useCallback(
+    async ({ loading }: { loading: boolean } = { loading: true }) => {
+      setIsLoading(loading);
       setError(null);
 
       try {
+        if (!dashboardId) {
+          setColumns(null);
+          return;
+        }
+
         const res = await getColumn({ dashboardId });
         setColumns(res?.data ?? []);
       } catch (e) {
@@ -32,9 +30,19 @@ export function useColumn(dashboardId: number | null) {
       } finally {
         setIsLoading(false);
       }
-    };
-    loadColumns();
-  }, [dashboardId, isLoadingToken]);
+    },
+    [dashboardId]
+  );
 
-  return { columns, isLoading, error };
+  useEffect(() => {
+    if (isLoadingToken) return;
+    loadColumns();
+  }, [isLoadingToken, loadColumns]);
+
+  return {
+    columns,
+    isLoadingColumns,
+    error,
+    reloadColumns: loadColumns,
+  };
 }

--- a/src/pages/dashboard/[id]/dashboard-content.tsx
+++ b/src/pages/dashboard/[id]/dashboard-content.tsx
@@ -1,13 +1,20 @@
 import ColorChip from "@/components/chips/chip-color/chips-color";
-import Column from "@/components/dashboard/column/column";
+import Column, { ColumnActionType } from "@/components/dashboard/column/column";
+import Dialog from "@/components/dialog";
 import Modal from "@/components/modal";
+import { MemberInfo } from "@/components/profile/member-info";
 import Typography from "@/components/typography";
 import { CommonSize } from "@/constants/common/common-size";
+import { CardParams, createCard, CreateCardParams } from "@/features/card/apis";
+import CardEditSheet from "@/features/card/components/card-edit-sheet";
+import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
+import { useSheet } from "@/hooks/use-sheet";
 import { Card } from "@/types/card";
 import { Column as ColumnData } from "@/types/column";
 import { Dashboard } from "@/types/dashboard";
 import { classnames } from "@/utils/classnames";
+import { useState } from "react";
 import styles from "./index.module.css";
 import PlusCircleSvg from "./plus-circle-svg";
 
@@ -20,23 +27,60 @@ export async function getServerSideProps() {
 interface DashboardContentProps {
   dashboard: Dashboard;
   columns: ColumnData[];
+  members: MemberInfo[];
   cards: Record<number, Card[]>;
   isLoading: boolean;
   onCardClick: (card: Card) => void;
+  onCardCreate: (newCard: Card) => void;
 }
 
 export default function DashboardContent({
   dashboard,
   columns,
+  members,
   cards,
   isLoading,
   onCardClick,
+  onCardCreate,
 }: DashboardContentProps) {
   const CREATE_COLUMN_MODAL_KEY = "CREATE_COLUMN_MODAL";
   const { isShowModal, openModal } = useModal({ key: CREATE_COLUMN_MODAL_KEY });
 
+  const CREATE_CARD_SHEET_KEY = "CREATE_CARD_SHEET";
+  const { isShowSheet, openSheet } = useSheet({ key: CREATE_CARD_SHEET_KEY });
+
+  const FAIL_DIALOG_KEY = "fail-dialog-from-dashboard-content";
+  const { isShowDialog, openDialog } = useDialog({ key: FAIL_DIALOG_KEY });
+  const [failMessage, setFailMessage] = useState("");
+
   const handleCreateColumnClick = () => {
     openModal(true);
+  };
+
+  const handleCardCreate = async (params?: CardParams) => {
+    if (!params) {
+      openSheet(true);
+      return;
+    }
+
+    try {
+      const createParams: CreateCardParams = {
+        ...params,
+        dashboardId: dashboard.id,
+      };
+      const newCard = await createCard({ params: createParams });
+      onCardCreate(newCard);
+      openSheet(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        openDialog(true);
+        setFailMessage(error.message);
+      }
+    }
+  };
+
+  const handleColumnUpdate = () => {
+    console.log("컬럼 수정 처리");
   };
 
   return (
@@ -59,6 +103,14 @@ export default function DashboardContent({
                   onCardClick={onCardClick}
                   columnTitle={column.title}
                   onClick={(type) => {
+                    switch (type) {
+                      case ColumnActionType.Create:
+                        handleCardCreate();
+                        break;
+                      case ColumnActionType.Modify:
+                        handleColumnUpdate();
+                        break;
+                    }
                     console.log(`${column.title} 컬럼의 ${type} 클릭`);
                   }}
                 />
@@ -99,6 +151,17 @@ export default function DashboardContent({
             <button onClick={() => openModal(false)}>Close Modal 1</button>
           </div>
         </Modal>
+      )}
+      {isShowSheet && (
+        <CardEditSheet
+          sheetKey={CREATE_CARD_SHEET_KEY}
+          columns={columns}
+          members={members}
+          onCreate={handleCardCreate}
+        />
+      )}
+      {isShowDialog && (
+        <Dialog dialogKey={FAIL_DIALOG_KEY} message={failMessage} />
       )}
     </>
   );

--- a/src/pages/dashboard/[id]/dashboard-content.tsx
+++ b/src/pages/dashboard/[id]/dashboard-content.tsx
@@ -1,17 +1,17 @@
 import ColorChip from "@/components/chips/chip-color/chips-color";
 import Column, { ColumnActionType } from "@/components/dashboard/column/column";
 import Dialog from "@/components/dialog";
-import Modal from "@/components/modal";
 import { MemberInfo } from "@/components/profile/member-info";
 import Typography from "@/components/typography";
 import { CommonSize } from "@/constants/common/common-size";
 import { CardParams, createCard, CreateCardParams } from "@/features/card/apis";
 import CardEditSheet from "@/features/card/components/card-edit-sheet";
+import { createColumn, updateColumn } from "@/features/column/apis";
+import ColumnEditSheet from "@/features/column/components/column-edit-sheet";
 import { useDialog } from "@/hooks/use-dialog";
-import { useModal } from "@/hooks/use-modal";
 import { useSheet } from "@/hooks/use-sheet";
 import { Card } from "@/types/card";
-import { Column as ColumnData } from "@/types/column";
+import { Column as ColumnType } from "@/types/column";
 import { Dashboard } from "@/types/dashboard";
 import { classnames } from "@/utils/classnames";
 import { useState } from "react";
@@ -26,7 +26,7 @@ export async function getServerSideProps() {
 
 interface DashboardContentProps {
   dashboard: Dashboard;
-  columns: ColumnData[];
+  columns: ColumnType[];
   members: MemberInfo[];
   cards: Record<number, Card[]>;
   isLoading: boolean;
@@ -43,8 +43,10 @@ export default function DashboardContent({
   onCardClick,
   onCardCreate,
 }: DashboardContentProps) {
-  const CREATE_COLUMN_MODAL_KEY = "CREATE_COLUMN_MODAL";
-  const { isShowModal, openModal } = useModal({ key: CREATE_COLUMN_MODAL_KEY });
+  const CREATE_COLUMN_SHEET_KEY = "CREATE_COLUMN_SHEET_KEY";
+  const { isShowSheet: isShowColumnEditSheet, openSheet: openColumnEditSheet } =
+    useSheet({ key: CREATE_COLUMN_SHEET_KEY });
+  const [editingColumn, setEditingColumn] = useState<ColumnType>();
 
   const CREATE_CARD_SHEET_KEY = "CREATE_CARD_SHEET";
   const { isShowSheet, openSheet } = useSheet({ key: CREATE_CARD_SHEET_KEY });
@@ -54,7 +56,12 @@ export default function DashboardContent({
   const [failMessage, setFailMessage] = useState("");
 
   const handleCreateColumnClick = () => {
-    openModal(true);
+    openColumnEditSheet(true);
+  };
+
+  const handleEditColumnClick = (column: ColumnType) => {
+    openColumnEditSheet(true);
+    setEditingColumn(column);
   };
 
   const handleCardCreate = async (params?: CardParams) => {
@@ -79,8 +86,24 @@ export default function DashboardContent({
     }
   };
 
-  const handleColumnUpdate = () => {
-    console.log("컬럼 수정 처리");
+  const handleColumnEdit = async (title: string) => {
+    try {
+      if (editingColumn) {
+        await updateColumn({ columnId: editingColumn.id, title });
+      } else {
+        await createColumn({ dashboardId: dashboard.id, title });
+      }
+      setEditingColumn(undefined);
+    } catch (error) {
+      if (error instanceof Error) {
+        openDialog(true);
+        setFailMessage(error.message);
+      }
+    }
+  };
+
+  const handleDialogConfirm = () => {
+    openDialog(false);
   };
 
   return (
@@ -108,10 +131,9 @@ export default function DashboardContent({
                         handleCardCreate();
                         break;
                       case ColumnActionType.Modify:
-                        handleColumnUpdate();
+                        handleEditColumnClick(column);
                         break;
                     }
-                    console.log(`${column.title} 컬럼의 ${type} 클릭`);
                   }}
                 />
               ))
@@ -132,25 +154,13 @@ export default function DashboardContent({
           </div>
         </div>
       </section>
-
-      {isShowModal && (
-        <Modal modalKey={CREATE_COLUMN_MODAL_KEY}>
-          <div
-            style={{
-              width: "600px",
-              height: "600px",
-              backgroundColor: "#242429",
-              borderRadius: "24px",
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <h2 style={{ color: "white" }}>새컬럼만들기모달</h2>
-            <button onClick={() => openModal(false)}>Close Modal 1</button>
-          </div>
-        </Modal>
+      {isShowColumnEditSheet && (
+        <ColumnEditSheet
+          sheetKey={CREATE_COLUMN_SHEET_KEY}
+          column={editingColumn}
+          usedTitles={[]}
+          onSubmit={handleColumnEdit}
+        />
       )}
       {isShowSheet && (
         <CardEditSheet
@@ -161,7 +171,11 @@ export default function DashboardContent({
         />
       )}
       {isShowDialog && (
-        <Dialog dialogKey={FAIL_DIALOG_KEY} message={failMessage} />
+        <Dialog
+          dialogKey={FAIL_DIALOG_KEY}
+          message={failMessage}
+          onConfirm={handleDialogConfirm}
+        />
       )}
     </>
   );

--- a/src/pages/dashboard/[id]/dashboard-content.tsx
+++ b/src/pages/dashboard/[id]/dashboard-content.tsx
@@ -29,9 +29,11 @@ interface DashboardContentProps {
   columns: ColumnType[];
   members: MemberInfo[];
   cards: Record<number, Card[]>;
-  isLoading: boolean;
+  isLoadingColumns: boolean;
+  isLoadingCards: boolean;
+  onColumnChange: () => void;
   onCardClick: (card: Card) => void;
-  onCardCreate: (newCard: Card) => void;
+  onCardChange: () => void;
 }
 
 export default function DashboardContent({
@@ -39,9 +41,11 @@ export default function DashboardContent({
   columns,
   members,
   cards,
-  isLoading,
+  isLoadingColumns,
+  isLoadingCards,
+  onColumnChange,
   onCardClick,
-  onCardCreate,
+  onCardChange,
 }: DashboardContentProps) {
   const CREATE_COLUMN_SHEET_KEY = "CREATE_COLUMN_SHEET_KEY";
   const { isShowSheet: isShowColumnEditSheet, openSheet: openColumnEditSheet } =
@@ -75,8 +79,8 @@ export default function DashboardContent({
         ...params,
         dashboardId: dashboard.id,
       };
-      const newCard = await createCard({ params: createParams });
-      onCardCreate(newCard);
+      await createCard({ params: createParams });
+      onCardChange();
       openSheet(false);
     } catch (error) {
       if (error instanceof Error) {
@@ -93,6 +97,7 @@ export default function DashboardContent({
       } else {
         await createColumn({ dashboardId: dashboard.id, title });
       }
+      onColumnChange();
       setEditingColumn(undefined);
     } catch (error) {
       if (error instanceof Error) {
@@ -116,13 +121,14 @@ export default function DashboardContent({
 
         <div className={styles.columnWrapper}>
           <div className={styles.columnContentWrapper}>
-            {isLoading ? (
+            {isLoadingColumns ? (
               <h2>컬럼 로딩중...</h2>
             ) : (
               columns.map((column) => (
                 <Column
                   key={column.id}
                   cards={cards[column.id] ?? []}
+                  isLoadingCards={isLoadingCards}
                   onCardClick={onCardClick}
                   columnTitle={column.title}
                   onClick={(type) => {

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -89,11 +89,11 @@ export default function DashboardPage() {
           )}
         </main>
       </div>
-      {isShowModal && selectedCard !== null && (
+      {isShowModal && selectedCard !== null && dashboard !== null && (
         <CardDetailModal
           modalKey={CARD_DETAIL_MODAL_KEY}
           card={selectedCard}
-          dashboardTitle={dashboard?.title ?? ""}
+          dashboard={dashboard}
           columns={columns ?? []}
           members={members ?? []}
           onDelete={handleCardDelete}

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -57,7 +57,7 @@ export default function DashboardPage() {
 
   const handleCardCreate = (newCard: Card) => {
     console.log("카드 생성 처리", newCard);
-  }
+  };
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -89,7 +89,6 @@ export default function DashboardPage() {
           )}
         </main>
       </div>
-
       {isShowModal && selectedCard !== null && (
         <CardDetailModal
           modalKey={CARD_DETAIL_MODAL_KEY}

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -23,40 +23,29 @@ export default function DashboardPage() {
 
   const { dashboard } = useDashboardById(dashboardId);
   const { members } = useMembers(dashboardId);
-  const { columns, isLoading: isColumnsLoading } = useColumn(dashboardId);
+  const { columns, isLoadingColumns, reloadColumns } = useColumn(dashboardId);
   const columnIds = useMemo(
     () => columns?.map((column) => column.id) ?? [],
     [columns]
   );
-  const { cards, isLoading: isCardsLoading } = useCards(columnIds);
-
-  const [stillLoading, setStillLoading] = useState(false);
-
-  useEffect(() => {
-    if (isColumnsLoading || isCardsLoading) {
-      setStillLoading(true);
-    } else {
-      setStillLoading(false);
-    }
-  }, [isColumnsLoading, isCardsLoading]);
-
-  const isLoading = stillLoading || isColumnsLoading || isCardsLoading;
+  const { cards, isLoadingCards, reloadCards } = useCards(columnIds);
 
   const [selectedCard, setSelectedCard] = useState<Card | null>(null);
+
   const CARD_DETAIL_MODAL_KEY = "card-detail-modal";
   const { isShowModal, openModal } = useModal({ key: CARD_DETAIL_MODAL_KEY });
+
+  const handleColumnChange = () => {
+    reloadColumns({ loading: false });
+  };
 
   const handleCardClick = (card: Card) => {
     setSelectedCard(card);
     openModal(true);
   };
 
-  const handleCardDelete = () => {
-    console.log("카드 삭제 처리");
-  };
-
-  const handleCardCreate = (newCard: Card) => {
-    console.log("카드 생성 처리", newCard);
+  const handleCardChange = () => {
+    reloadCards({ loading: false });
   };
 
   useEffect(() => {
@@ -82,9 +71,11 @@ export default function DashboardPage() {
               columns={columns ?? []}
               members={members ?? []}
               cards={cards ?? {}}
-              isLoading={isLoading}
+              isLoadingColumns={isLoadingColumns}
+              isLoadingCards={isLoadingCards}
               onCardClick={handleCardClick}
-              onCardCreate={handleCardCreate}
+              onCardChange={handleCardChange}
+              onColumnChange={handleColumnChange}
             />
           )}
         </main>
@@ -96,7 +87,8 @@ export default function DashboardPage() {
           dashboard={dashboard}
           columns={columns ?? []}
           members={members ?? []}
-          onDelete={handleCardDelete}
+          onDelete={handleCardChange}
+          onUpdate={handleCardChange}
         />
       )}
     </div>

--- a/src/pages/dashboard/[id]/index.tsx
+++ b/src/pages/dashboard/[id]/index.tsx
@@ -1,6 +1,6 @@
 import DashboardSideBar from "@/components/dashboard-side-bar/dashboard-side-bar";
-import Modal from "@/components/modal";
 import NavigationBar from "@/components/navigationBar/navigation-bar";
+import CardDetailModal from "@/features/card/components/card-detail-modal";
 import { useCards } from "@/hooks/use-cards";
 import { useColumn } from "@/hooks/use-column";
 import { useDashboardById } from "@/hooks/use-dashboard";
@@ -43,15 +43,21 @@ export default function DashboardPage() {
   const isLoading = stillLoading || isColumnsLoading || isCardsLoading;
 
   const [selectedCard, setSelectedCard] = useState<Card | null>(null);
-  const MODAL_KEY_1 = "CARD_MODAL";
-  const { isShowModal: isShowModal1, openModal: openModal1 } = useModal({
-    key: MODAL_KEY_1,
-  });
+  const CARD_DETAIL_MODAL_KEY = "card-detail-modal";
+  const { isShowModal, openModal } = useModal({ key: CARD_DETAIL_MODAL_KEY });
 
   const handleCardClick = (card: Card) => {
     setSelectedCard(card);
-    openModal1(true);
+    openModal(true);
   };
+
+  const handleCardDelete = () => {
+    console.log("카드 삭제 처리");
+  };
+
+  const handleCardCreate = (newCard: Card) => {
+    console.log("카드 생성 처리", newCard);
+  }
 
   useEffect(() => {
     if (!router.isReady) return;
@@ -74,33 +80,25 @@ export default function DashboardPage() {
             <DashboardContent
               dashboard={dashboard}
               columns={columns ?? []}
+              members={members ?? []}
               cards={cards ?? {}}
               isLoading={isLoading}
               onCardClick={handleCardClick}
+              onCardCreate={handleCardCreate}
             />
           )}
         </main>
       </div>
 
-      {isShowModal1 && (
-        <Modal modalKey={MODAL_KEY_1}>
-          <div
-            style={{
-              width: "600px",
-              height: "600px",
-              backgroundColor: "#242429",
-              borderRadius: "24px",
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <h2 style={{ color: "white" }}>Modal 1 Title</h2>
-            <div>{selectedCard && JSON.stringify(selectedCard, null, 2)}</div>
-            <button onClick={() => openModal1(false)}>Close Modal 1</button>
-          </div>
-        </Modal>
+      {isShowModal && selectedCard !== null && (
+        <CardDetailModal
+          modalKey={CARD_DETAIL_MODAL_KEY}
+          card={selectedCard}
+          dashboardTitle={dashboard?.title ?? ""}
+          columns={columns ?? []}
+          members={members ?? []}
+          onDelete={handleCardDelete}
+        />
       )}
     </div>
   );

--- a/src/pages/test-components/index.tsx
+++ b/src/pages/test-components/index.tsx
@@ -9,6 +9,7 @@ import ColorChip from "@/components/chips/chip-color/chips-color";
 import { ColorFrameSize } from "@/components/chips/color-frame/color-frame-size";
 import { Color } from "@/components/color";
 import ColorPalette from "@/components/color-palette/color-palette";
+import { getColumn } from "@/components/dashboard/column/mock";
 import Dialog from "@/components/dialog";
 import Input, { InputSize, InputVariant } from "@/components/input/input";
 import Textarea, { TextareaSize } from "@/components/input/textarea";
@@ -25,15 +26,18 @@ import { ProfileRandomColor } from "@/constants/profile-random-color";
 import { logout } from "@/features/auth/apis/logout";
 import { getCard } from "@/features/card/apis/mock";
 import CardDetailModal from "@/features/card/components/card-detail-modal";
+import CardEditSheet from "@/features/card/components/card-edit-sheet";
 import Dropdown, { DropdownOption } from "@/features/card/components/dropdown";
 import ImageInput from "@/features/card/components/image-input";
 import { Direction, Menu, MenuItem } from "@/features/card/components/menu";
 import TagInput from "@/features/card/components/tag-input";
 import ColumnEditSheet from "@/features/column/components/column-edit-sheet";
+import { getMembers } from "@/features/member/apis/mock";
 import { useAlert } from "@/hooks/use-alert";
 import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
 import { useSheet } from "@/hooks/use-sheet";
+import { Column, MemberInfo } from "@/types";
 import { Card } from "@/types/card";
 import { ReactNode, useEffect, useState } from "react";
 
@@ -664,6 +668,64 @@ function SheetSample() {
   );
 }
 
+function CardEditSheetSample() {
+  const SHEET_KEY = "card-edit-sheet-sample";
+  const { isShowSheet, openSheet } = useSheet({
+    key: SHEET_KEY,
+  });
+
+  const SHEET_KEY_WITH_CARD = "card-edit-sheet-sample-with-card";
+  const { isShowSheet: isShowSheetWithCard, openSheet: openSheetWithCard } =
+    useSheet({
+      key: SHEET_KEY_WITH_CARD,
+    });
+
+  const [card, setCard] = useState<Card | null>(null);
+  const [columns, setColumns] = useState<Column[]>([]);
+  const [members, setMembers] = useState<MemberInfo[]>([]);
+
+  useEffect(() => {
+    async function loadCard() {
+      const [card, columns, members] = await Promise.all([
+        getCard(),
+        getColumn({ dashboardId: 1234 }),
+        getMembers(),
+      ]);
+
+      setCard(card);
+      setColumns(columns);
+      setMembers(members);
+    }
+    loadCard();
+  }, []);
+
+  return (
+    <>
+      <div>
+        <button onClick={() => openSheet(true)}>Open Sheet</button>
+        <button onClick={() => openSheetWithCard(true)}>
+          Open Sheet with Card
+        </button>
+        {isShowSheet && (
+          <CardEditSheet
+            sheetKey={SHEET_KEY}
+            columns={columns}
+            members={members}
+          />
+        )}
+        {isShowSheetWithCard && (
+          <CardEditSheet
+            sheetKey={SHEET_KEY_WITH_CARD}
+            card={card || undefined}
+            columns={columns}
+            members={members}
+          />
+        )}
+      </div>
+    </>
+  );
+}
+
 function ColumnEditSheetSample() {
   const SHEET_KEY1 = "COLUMN_EDIT_SHEET_SAMPLE_1";
   const { isShowSheet: isShowSheet1, openSheet: openSheet1 } = useSheet({
@@ -769,11 +831,22 @@ function LogoutButton() {
 function CardDetailModalSample() {
   const modalKey = "card-detail";
   const { isShowModal, openModal } = useModal({ key: modalKey });
+
   const [card, setCard] = useState<Card | null>(null);
+  const [columns, setColumns] = useState<Column[]>([]);
+  const [members, setMembers] = useState<MemberInfo[]>([]);
+
   useEffect(() => {
     async function loadCard() {
-      const card = await getCard();
+      const [card, columns, members] = await Promise.all([
+        getCard(),
+        getColumn({ dashboardId: 1234 }),
+        getMembers(),
+      ]);
+
       setCard(card);
+      setColumns(columns);
+      setMembers(members);
     }
     loadCard();
   }, []);
@@ -788,6 +861,9 @@ function CardDetailModalSample() {
             card={card}
             columnTitle="Progress"
             dashboardTitle="포트폴리오"
+            columns={columns}
+            members={members}
+            onDelete={() => console.log("Delete Card")}
           />
         )}
       </div>
@@ -850,6 +926,9 @@ export default function Page() {
       </Section>
       <Section title="Sheet">
         <SheetSample />
+      </Section>
+      <Section title="CardEditSheet">
+        <CardEditSheetSample />
       </Section>
       <Section title="ColumnEditSheet">
         <ColumnEditSheetSample />

--- a/src/types/card.ts
+++ b/src/types/card.ts
@@ -1,14 +1,16 @@
+export interface CardAssignee {
+  profileImageUrl: string;
+  nickname: string;
+  id: number;
+}
+
 export interface Card {
   id: number;
   title: string;
   description: string;
   tags: string[];
   dueDate: string;
-  assignee: {
-    profileImageUrl: string;
-    nickname: string;
-    id: number;
-  };
+  assignee: CardAssignee;
   imageUrl: string;
   teamId: string;
   columnId: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,5 @@
+export type { Card } from "./card";
+export type { Column } from "./column";
+export type { Comment } from "./comment";
+export type { Dashboard } from "./dashboard";
+export type { MemberInfo } from "./member-info";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export type { Card } from "./card";
+export type { Card, CardAssignee } from "./card";
 export type { Column } from "./column";
 export type { Comment } from "./comment";
 export type { Dashboard } from "./dashboard";

--- a/src/utils/date-formatter.ts
+++ b/src/utils/date-formatter.ts
@@ -11,11 +11,8 @@ export function formatDueDate(dateString: string) {
 export function formatFullDate(dateString: string) {
   const date = new Date(dateString);
   const formatter = new Intl.DateTimeFormat("ko-KR", {
-    year: "numeric",
-    month: "long",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
+    dateStyle: "long",
+    timeStyle: "short",
   });
   return formatter.format(date);
 }


### PR DESCRIPTION
## 📝 작업 내용

- Column 생성 및 수정 시 `ColumnEditSheet`를 사용합니다.
- Card를 클릭했을 때 `CardDetailModal`을 사용해서 card 상세 내용을 보여줍니다.
- Card 생성 및 수정 시 `CardEditSheet`를 사용합니다.
- `CardDetailModal`에서 comment 기능에 API를 연동합니다.

## 📷 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/166b83b9-cb65-471e-a20a-405990632f6a" width="500px" />

## 🧐 해결해야 하는 문제 (선택)

- Column loading UI 구현
- Column 내부 cards loading UI 구현
- 최초 loading이 완료된 후 data 변경을 위한 reload 시점엔 loading UI를 보여주지 않음
- Modal, Sheet, Dialog 사용 시 화면이 깜빡이는 문제 수정

## 💬 리뷰어에게 남길 말 (선택)

@nidor022 

- 아래 파일이 함께 수정되었으니 참고해주세요.
  - `pages/dashboard/[id]/index.tsx`
  - `pages/dashboard/[id]/dashboard-context.tsx`
  - `hooks/use-cards.tsx`
  - `hooks/use-column.tsx`