### PR TITLE
[#150] Tags history 기능 구현

### DIFF
--- a/src/features/card/components/tag-input/index.tsx
+++ b/src/features/card/components/tag-input/index.tsx
@@ -133,6 +133,11 @@ export default function TagInput({ tags = [], onChange }: Props) {
     }
   }, [isEditing]);
 
+  useEffect(() => {
+    addTagsHistory(tags);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tags]);
+
   return (
     <div className={styles.container} ref={tagInputRef}>
       <div

--- a/src/features/card/components/tag-input/index.tsx
+++ b/src/features/card/components/tag-input/index.tsx
@@ -2,16 +2,9 @@ import Badge from "@/components/chips/badge/badge";
 import Typography from "@/components/typography";
 import { useBackdropClick } from "@/hooks/use-backdrop-unmount";
 import { classnames } from "@/utils/classnames";
-import {
-  ChangeEvent,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
 import styles from "./tag-input.module.css";
-import { TagsContext } from "./tags-provider";
+import { useTagsHistory } from "./tags-provider";
 
 function TagList({ tags }: { tags: string[] }) {
   return (
@@ -94,7 +87,7 @@ export default function TagInput({ tags = [], onChange }: Props) {
     },
   });
   const inputRef = useRef<HTMLInputElement>(null);
-  const { tagsHistory, setTagsHistory } = useContext(TagsContext);
+  const { tagsHistory, addTagsHistory } = useTagsHistory();
 
   const showsBadgeList = useMemo(() => {
     return tags.length > 0 && !isEditing;
@@ -127,7 +120,7 @@ export default function TagInput({ tags = [], onChange }: Props) {
     }
 
     onChange?.([...tags, value]);
-    setTagsHistory([...tagsHistory, value]);
+    addTagsHistory(value);
     setInputValue("");
     setEditing(false);
   };

--- a/src/features/card/components/tag-input/tags-provider.tsx
+++ b/src/features/card/components/tag-input/tags-provider.tsx
@@ -20,11 +20,13 @@ interface Props {
   children: ReactNode;
 }
 
+const STORAGE_KEY = "tagsHistory";
+
 export default function TagsProvider({ children }: Props) {
   const [tagsHistory, setTagsHistory] = useState<string[]>([]);
 
   const addTagsHistory = (tag: string) => {
-    localStorage.setItem("tagsHistory", JSON.stringify([...tagsHistory, tag]));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([...tagsHistory, tag]));
     setTagsHistory((prev) => {
       if (prev.includes(tag)) return prev;
       return [...prev, tag];
@@ -32,7 +34,7 @@ export default function TagsProvider({ children }: Props) {
   };
 
   useEffect(() => {
-    const storedTagsHistory = localStorage.getItem("tagsHistory");
+    const storedTagsHistory = localStorage.getItem(STORAGE_KEY);
     if (storedTagsHistory) {
       setTagsHistory(JSON.parse(storedTagsHistory));
     }

--- a/src/features/card/components/tag-input/tags-provider.tsx
+++ b/src/features/card/components/tag-input/tags-provider.tsx
@@ -1,19 +1,19 @@
 import {
   createContext,
-  Dispatch,
   ReactNode,
-  SetStateAction,
+  useContext,
+  useEffect,
   useState,
 } from "react";
 
 interface ContextValue {
   tagsHistory: string[];
-  setTagsHistory: Dispatch<SetStateAction<string[]>>;
+  addTagsHistory: (tag: string) => void;
 }
 
-export const TagsContext = createContext<ContextValue>({
+const TagsContext = createContext<ContextValue>({
   tagsHistory: [],
-  setTagsHistory: () => {},
+  addTagsHistory: () => {},
 });
 
 interface Props {
@@ -23,9 +23,36 @@ interface Props {
 export default function TagsProvider({ children }: Props) {
   const [tagsHistory, setTagsHistory] = useState<string[]>([]);
 
+  const addTagsHistory = (tag: string) => {
+    localStorage.setItem("tagsHistory", JSON.stringify([...tagsHistory, tag]));
+    setTagsHistory((prev) => {
+      if (prev.includes(tag)) return prev;
+      return [...prev, tag];
+    });
+  };
+
+  useEffect(() => {
+    const storedTagsHistory = localStorage.getItem("tagsHistory");
+    if (storedTagsHistory) {
+      setTagsHistory(JSON.parse(storedTagsHistory));
+    }
+  }, []);
+
   return (
-    <TagsContext value={{ tagsHistory, setTagsHistory }}>
+    <TagsContext value={{ tagsHistory, addTagsHistory }}>
       {children}
     </TagsContext>
   );
+}
+
+export function useTagsHistory() {
+  const context = useContext(TagsContext);
+  if (!context) {
+    throw new Error("useTagsHistory must be used within a TagsProvider");
+  }
+
+  return {
+    tagsHistory: context.tagsHistory,
+    addTagsHistory: context.addTagsHistory,
+  };
 }

--- a/src/features/card/components/tag-input/tags-provider.tsx
+++ b/src/features/card/components/tag-input/tags-provider.tsx
@@ -8,7 +8,7 @@ import {
 
 interface ContextValue {
   tagsHistory: string[];
-  addTagsHistory: (tag: string) => void;
+  addTagsHistory: (tags: string | string[]) => void;
 }
 
 const TagsContext = createContext<ContextValue>({
@@ -25,11 +25,15 @@ const STORAGE_KEY = "tagsHistory";
 export default function TagsProvider({ children }: Props) {
   const [tagsHistory, setTagsHistory] = useState<string[]>([]);
 
-  const addTagsHistory = (tag: string) => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify([...tagsHistory, tag]));
+  const addTagsHistory = (tags: string | string[]) => {
+    const tagsArray = Array.isArray(tags) ? tags : [tags];
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify([...tagsHistory, ...tagsArray])
+    );
     setTagsHistory((prev) => {
-      if (prev.includes(tag)) return prev;
-      return [...prev, tag];
+      const newTags = tagsArray.filter((tag) => !prev.includes(tag));
+      return [...prev, ...newTags];
     });
   };
 


### PR DESCRIPTION
## 📝 작업 내용

- `CardEditSheet`에서 `TagInput`을 열었을 때 이전에 만들었던 tag들의 history를 표시하는 기능을 개발합니다.
- Taskify API가 tag history 기능을 지원하지 않아서, local storage를 사용해서 임의로 구현합니다.
- `CardDetailModal`에서 '수정하기' 기능을 통해 `CardEditSheet`에 접근하면, card에 설정되어 있는 tag들이 history에 저장됩니다.
- `CardEditSheet`에서 `TagInput`을 통해 새 tag를 생성하면 history에 저장됩니다.

## 📷 스크린샷 (선택)

https://github.com/user-attachments/assets/6c86b686-dd58-41bc-b022-91d9b12fe097
