### PR TITLE
[#186] 프로필 컴포넌트 이름 한글자만 표시되도록 수정

### DIFF
--- a/src/components/profile-setting-modal/profile-setting-modal.module.css
+++ b/src/components/profile-setting-modal/profile-setting-modal.module.css
@@ -15,6 +15,7 @@
   width: 120px;
   height: 120px;
   object-fit: cover;
+  font-size: 56px;
 }
 
 .emailSection {

--- a/src/components/profile/profile.tsx
+++ b/src/components/profile/profile.tsx
@@ -53,8 +53,7 @@ export default function Profile({
   }, [colorIndex, name, isRemain]);
 
   const visualLength = localeLengthKR(name);
-  const spanClasses =
-    visualLength >= 5 ? styles.alignStart : styles.alignCenter;
+  const spanClasses = styles.alignCenter;
 
   const profileClasses = classnames(
     styles.profile,
@@ -76,7 +75,7 @@ export default function Profile({
         </div>
       ) : (
         <div className={profileClasses} style={{ backgroundColor }}>
-          <span className={spanClasses}>{name}</span>
+          <span className={spanClasses}>{name[0]}</span>
         </div>
       )}
       {showFullName && (


### PR DESCRIPTION
## 📝 작업 내용

프로필 컴포넌트의 유저 이름 앞 한글자만 표시되도록 수정

## 📷 스크린샷 (선택)

<img width="170" height="68" alt="image" src="https://github.com/user-attachments/assets/fc5e9a9d-9be5-4f1a-9ef7-0c2de2ee1df2" />
<img width="727" height="265" alt="image" src="https://github.com/user-attachments/assets/3fbd479e-3fca-48e7-9323-82258d810e23" />

