### PR TITLE
[#207] 유저관리, 비밀번호변경창 반응형 추가 (Mobile)

### DIFF
--- a/src/components/modal/modal.module.css
+++ b/src/components/modal/modal.module.css
@@ -23,6 +23,9 @@
 .content.fullscreen {
   border: none;
   border-radius: 0px;
+  max-width: none;
+  width: 100vw;
+  height: 100vh;
 }
 
 @keyframes fadeIn {

--- a/src/components/profile-setting-modal/index.tsx
+++ b/src/components/profile-setting-modal/index.tsx
@@ -11,7 +11,6 @@ import { getMe, GetMeResponse } from "@/features/user/apis/get-me";
 import { uploadProfileImage } from "@/features/user/apis/upload-profile-image";
 import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
-import { useResponsive } from "@/hooks/use-responsive";
 import { staticImageDataToFile } from "@/utils/static-image-data-to-file";
 import { AxiosError } from "axios";
 import { useEffect, useRef, useState } from "react";
@@ -38,7 +37,6 @@ export default function AccountSettingModal({ zIndex }: { zIndex: boolean }) {
   const [dialogMessage, setDialogMessage] = useState("");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isSubmitEnabled, setIsSubmitEnabled] = useState(false);
-  const { isMobile } = useResponsive();
 
   useAuthEffect(() => {
     if (!isShowModal) return;
@@ -113,6 +111,8 @@ export default function AccountSettingModal({ zIndex }: { zIndex: boolean }) {
     }
   };
 
+  const isMobile = typeof window !== "undefined" && window.innerWidth <= 375;
+
   return (
     <>
       {isShowModal && (
@@ -122,6 +122,7 @@ export default function AccountSettingModal({ zIndex }: { zIndex: boolean }) {
           actionType={SheetActionType.Update}
           onAction={handleSubmit}
           canSubmit={isSubmitEnabled}
+          isFullScreen={isMobile}
         >
           <div className={styles.body}>
             <section className={styles.profileImageSection}>

--- a/src/components/profile-setting-modal/index.tsx
+++ b/src/components/profile-setting-modal/index.tsx
@@ -11,6 +11,7 @@ import { getMe, GetMeResponse } from "@/features/user/apis/get-me";
 import { uploadProfileImage } from "@/features/user/apis/upload-profile-image";
 import { useDialog } from "@/hooks/use-dialog";
 import { useModal } from "@/hooks/use-modal";
+import { useResponsive } from "@/hooks/use-responsive";
 import { staticImageDataToFile } from "@/utils/static-image-data-to-file";
 import { AxiosError } from "axios";
 import { useEffect, useRef, useState } from "react";
@@ -37,6 +38,7 @@ export default function AccountSettingModal({ zIndex }: { zIndex: boolean }) {
   const [dialogMessage, setDialogMessage] = useState("");
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isSubmitEnabled, setIsSubmitEnabled] = useState(false);
+  const { isMobile } = useResponsive();
 
   useAuthEffect(() => {
     if (!isShowModal) return;

--- a/src/components/profile-setting-modal/password-change-modal.module.css
+++ b/src/components/profile-setting-modal/password-change-modal.module.css
@@ -9,4 +9,5 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  margin-top: 16px;
 }

--- a/src/components/profile-setting-modal/password-change-modal.tsx
+++ b/src/components/profile-setting-modal/password-change-modal.tsx
@@ -95,6 +95,8 @@ export default function PasswordChangeModal({
     }
   };
 
+  const isMobile = typeof window !== "undefined" && window.innerWidth <= 375;
+
   return (
     <Sheet
       sheetKey={modalKey}
@@ -102,6 +104,7 @@ export default function PasswordChangeModal({
       actionType={SheetActionType.Update}
       canSubmit={!isSubmitButtonDisabled}
       onAction={handleSubmit}
+      isFullScreen={isMobile}
     >
       <div className={styles.body}>
         <section className={styles.inputSection}>

--- a/src/components/profile-setting-modal/profile-setting-modal.module.css
+++ b/src/components/profile-setting-modal/profile-setting-modal.module.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   gap: 30px;
   color: var(--color-gray300);
+  margin-top: 16px;
 }
 
 .profileImageSection {

--- a/src/components/sheet/index.tsx
+++ b/src/components/sheet/index.tsx
@@ -4,10 +4,10 @@ import Modal from "@/components/modal";
 import Typography from "@/components/typography";
 import { ModalZIndex } from "@/constants/modal-z-index";
 import { useSheet } from "@/hooks/use-sheet";
+import { useSsrResponsive } from "@/hooks/use-ssr-responsive";
 import { classnames } from "@/utils/classnames";
 import { MouseEventHandler, ReactNode, useMemo } from "react";
 import styles from "./sheet.module.css";
-import { useSsrResponsive } from "@/hooks/use-ssr-responsive";
 
 export enum SheetActionType {
   Cancel = "취소",
@@ -66,6 +66,7 @@ interface Props {
   children: ReactNode;
   onCancel?: () => void;
   onAction?: () => void;
+  isFullScreen?: boolean;
 }
 
 export default function Sheet({
@@ -76,6 +77,7 @@ export default function Sheet({
   children,
   onCancel,
   onAction,
+  isFullScreen = false,
 }: Props) {
   const { openSheet } = useSheet({ key: sheetKey });
   const { isMobile } = useSsrResponsive();
@@ -98,7 +100,11 @@ export default function Sheet({
   };
 
   return (
-    <Modal modalKey={sheetKey} zIndex={ModalZIndex.Over}>
+    <Modal
+      modalKey={sheetKey}
+      zIndex={ModalZIndex.Over}
+      isFullScreen={isFullScreen}
+    >
       <div className={styles.sheet}>
         <div className={styles.header}>
           <h2 className={classnames(styles.title, titleTypography)}>{title}</h2>


### PR DESCRIPTION
## 📝 작업 내용

유저관리, 비밀번호변경창 반응형 추가 (Mobile)

## 📷 스크린샷 (선택)

<img width="412" height="717" alt="image" src="https://github.com/user-attachments/assets/874f0de8-bc6a-40c7-aa76-7b985176d54e" />



## 🧐 해결해야 하는 문제 (선택)

PC, Table 반응형 추가
